### PR TITLE
docs: VitePress site with GitHub Pages deploy on version tag

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: '24'
       - uses: pnpm/action-setup@v4
       - name: Install Dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: Build Docs
         run: pnpm docs:build
       - name: Upload Pages Artifact

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,46 @@
+name: Deploy Docs
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - uses: pnpm/action-setup@v4
+      - name: Install Dependencies
+        run: pnpm install
+      - name: Build Docs
+        run: pnpm docs:build
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-05-08
+
+### Added
+- `Play` — immutable chainable builder for structured test scenarios (`.nav`, `.prep`, `.reload`, `.detect`, `.attempt`, `.cleanup`).
+- `Playbook` — named play-factory registry with `withCtx()` for binding page and custom context.
+- `Director` — `assertCan`, `assertCannot`, `ensureExists` for RBAC testing and fixture setup.
+- `SyncStrategy` — `default()`, `withReload()`, `custom(fn)` for multi-page sync in `ensureExists`.
+- `Outcomes` positional API: `success(locator)`, `success(name, locator)`, `failure(...)`, `timeout(after)`, `actionError(name)`. Locator arg accepts `(page, ctx) => Locator` for access to full Playbook context.
+- Sugar Lab playground app for integration testing.
+- VitePress documentation site, deployed to GitHub Pages on version tags.
+
+### Changed
+- `Outcomes` DSL switched from object-config to positional API (breaking — v0.1 had no published consumers).
+
 ## [0.1.0] - 2026-05-07
 
 ### Added

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,11 +3,12 @@ import { defineConfig } from 'vitepress'
 export default defineConfig({
   title: "Playwright Sugar",
   description: "Sweet utilities for Playwright automation",
+  base: '/playwright-sugar/',
   themeConfig: {
     logo: '/logo.png',
     nav: [
       { text: 'Guide', link: '/guide/getting-started' },
-      { text: 'API', link: '/api/' },
+      { text: 'API', link: '/api/attempt-action' },
       { text: 'GitHub', link: 'https://github.com/rickcedwhat/playwright-sugar' }
     ],
     sidebar: [
@@ -15,17 +16,26 @@ export default defineConfig({
         text: 'Introduction',
         items: [
           { text: 'Getting Started', link: '/guide/getting-started' },
-          { text: 'Philosophy', link: '/guide/philosophy' }
         ]
       },
       {
         text: 'Core Helpers',
         items: [
           { text: 'attemptAction', link: '/api/attempt-action' },
+          { text: 'Outcomes', link: '/api/outcomes' },
           { text: 'relator', link: '/api/relator' },
           { text: 'verifiedFill', link: '/api/verified-fill' },
+          { text: 'clickToOpen', link: '/api/click-to-open' },
           { text: 'findByScrolling', link: '/api/find-by-scrolling' },
-          { text: 'clickToOpen', link: '/api/click-to-open' }
+        ]
+      },
+      {
+        text: 'Director API',
+        items: [
+          { text: 'Play', link: '/api/play' },
+          { text: 'Playbook', link: '/api/playbook' },
+          { text: 'Director', link: '/api/director' },
+          { text: 'SyncStrategy', link: '/api/sync-strategy' },
         ]
       }
     ],

--- a/docs/api/attempt-action.md
+++ b/docs/api/attempt-action.md
@@ -16,7 +16,7 @@ attemptAction(params: {
 |---|---|---|
 | `action` | `() => Promise<void>` | Optional. The interaction to perform before waiting for outcomes. |
 | `outcomes` | `Outcome[]` | At least one outcome to watch for. Use the [`Outcomes`](/api/outcomes) DSL to build them. |
-| `timeout` | `number` | Overall timeout in ms. Overridden by a `Outcomes.timeout(after)` if present. |
+| `timeout` | `number` | Overall timeout in ms. Overridden by an `Outcomes.timeout(after)` if present. |
 
 ## Return value
 

--- a/docs/api/attempt-action.md
+++ b/docs/api/attempt-action.md
@@ -1,0 +1,73 @@
+# attemptAction
+
+Runs an optional action and waits for one of several named outcomes to appear. Returns the winning outcome rather than throwing, making it safe to branch on RBAC failures, toast messages, or missing UI elements.
+
+## Signature
+
+```ts
+attemptAction(params: {
+  action?: () => Promise<void>;
+  outcomes: Outcome[];
+  timeout?: number;
+}): Promise<{ isSuccess: boolean; outcome: string; data?: unknown }>
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `action` | `() => Promise<void>` | Optional. The interaction to perform before waiting for outcomes. |
+| `outcomes` | `Outcome[]` | At least one outcome to watch for. Use the [`Outcomes`](/api/outcomes) DSL to build them. |
+| `timeout` | `number` | Overall timeout in ms. Overridden by a `Outcomes.timeout(after)` if present. |
+
+## Return value
+
+| Field | Type | Description |
+|---|---|---|
+| `isSuccess` | `boolean` | `true` if the winning outcome was created with `Outcomes.success`. |
+| `outcome` | `string` | The name of the winning outcome. |
+| `data` | `unknown` | Optional data returned by the outcome's `onOutcome` callback. |
+
+## Examples
+
+### Success / failure branch
+
+```ts
+const result = await attemptAction({
+  action: async () => {
+    await page.getByRole('button', { name: 'Submit' }).click();
+  },
+  outcomes: [
+    Outcomes.success(page.getByText('Saved')),
+    Outcomes.failure(page.getByText('Permission denied')),
+    Outcomes.timeout(5000),
+  ],
+});
+
+expect(result.isSuccess).toBe(true);
+```
+
+### Action error vs timeout
+
+```ts
+const result = await attemptAction({
+  action: async () => {
+    await page.locator('#missing-btn').click({ timeout: 500 });
+  },
+  outcomes: [
+    Outcomes.success(page.getByText('Done')),
+    Outcomes.actionError('button-missing'),
+    Outcomes.timeout(3000),
+  ],
+});
+// result.outcome === 'button-missing' when the click throws
+```
+
+### No action (detect-only)
+
+```ts
+const result = await attemptAction({
+  outcomes: [
+    Outcomes.success(page.getByText('Welcome')),
+    Outcomes.failure(page.getByText('Session expired')),
+  ],
+});
+```

--- a/docs/api/click-to-open.md
+++ b/docs/api/click-to-open.md
@@ -1,0 +1,39 @@
+# clickToOpen
+
+Clicks a trigger element and retries until a target element becomes visible. Use when a single click is not always sufficient — for example, a button that opens a panel only after its data has loaded.
+
+## Signature
+
+```ts
+clickToOpen(
+  trigger: Locator,
+  target: Locator,
+  options?: {
+    maxRetries?: number;
+    timeout?: number;
+    subTimeout?: number;
+  }
+): Promise<void>
+```
+
+| Option | Default | Description |
+|---|---|---|
+| `maxRetries` | `3` | Maximum number of click attempts. |
+| `timeout` | `30000` | Overall timeout in ms. |
+| `subTimeout` | `2000` | How long to wait for the target after each click. |
+
+Throws if the target never appears within `timeout` ms or after `maxRetries` attempts.
+
+## Example
+
+```ts
+import { clickToOpen } from '@rickcedwhat/playwright-sugar';
+
+await clickToOpen(
+  page.getByRole('button', { name: 'Open panel' }),
+  page.getByRole('dialog'),
+  { subTimeout: 1000, maxRetries: 3 }
+);
+
+await expect(page.getByRole('dialog')).toBeVisible();
+```

--- a/docs/api/director.md
+++ b/docs/api/director.md
@@ -1,0 +1,75 @@
+# Director
+
+Runs plays from a `Playbook` and makes assertions about whether they succeeded or failed. The primary entry point for RBAC testing and fixture setup.
+
+## assertCan
+
+```ts
+director.assertCan(
+  playbook: Playbook,
+  playName: string,
+  params: unknown
+): Promise<PlayResult>
+```
+
+Runs the named play and **throws** if it does not produce a success outcome. Use to assert that a user *can* perform an action.
+
+```ts
+const director = new Director();
+const pb = datasetPb.withCtx({ page });
+
+await director.assertCan(pb, 'create', { name: 'My Dataset' });
+```
+
+## assertCannot
+
+```ts
+director.assertCannot(
+  playbook: Playbook,
+  playName: string,
+  params: unknown
+): Promise<PlayResult>
+```
+
+Runs the named play and **throws** if it produces a success outcome. Use to assert that a user *cannot* perform an action.
+
+```ts
+await page.goto('/?role=viewer');
+const result = await director.assertCannot(pb, 'create', { name: 'Blocked' });
+expect(result.isSuccess).toBe(false);
+```
+
+## ensureExists
+
+```ts
+director.ensureExists(
+  playbook: Playbook,
+  params: unknown,
+  opts?: { syncTo: Page; syncStrategy?: SyncStrategy }
+): Promise<void>
+```
+
+Runs the `exists` play. If it returns a failure outcome, runs the `create` play. Requires the Playbook to define both `exists` and `create` plays.
+
+If `syncTo` is provided, syncs state to a second page and retries `exists` there until it passes (up to 30 s).
+
+```ts
+// Ensure a dataset exists before the test body
+await director.ensureExists(pb, { name: 'Fixture Dataset' });
+
+// Ensure it's also visible on a second page
+await director.ensureExists(adminPb, { name: 'Shared Dataset' }, {
+  syncTo: viewerPage,
+  syncStrategy: SyncStrategy.withReload(),
+});
+```
+
+## PlayResult
+
+```ts
+type PlayResult = {
+  isSuccess: boolean;
+  outcome: string;
+  data?: unknown;
+}
+```

--- a/docs/api/find-by-scrolling.md
+++ b/docs/api/find-by-scrolling.md
@@ -1,0 +1,60 @@
+# findByScrolling
+
+Scrolls a container until a target element is found. Supports virtualized lists and infinite-scroll pages where elements are not in the DOM until scrolled into view.
+
+## Signature
+
+```ts
+findByScrolling(
+  target: Locator,
+  options?: FindByScrollingOptions
+): Promise<void>
+```
+
+```ts
+interface FindByScrollingOptions {
+  container?: Locator;
+  maxAttempts?: number;      // default: 50
+  waitAfterStep?: number;    // default: 200 ms
+  scrollStrategy?: ScrollStrategy;
+  endStrategy?: EndStrategy;
+  matchStrategy?: MatchStrategy;
+  stepAmount?: number;       // default: 600 px (simple shorthand)
+  stepAction?: () => Promise<void>; // custom scroll action shorthand
+}
+```
+
+## Basic example
+
+```ts
+import { findByScrolling } from '@rickcedwhat/playwright-sugar';
+
+await findByScrolling(page.getByText('Item #500'), {
+  container: page.locator('.virtual-list'),
+  stepAmount: 400,
+});
+
+await expect(page.getByText('Item #500')).toBeVisible();
+```
+
+## Strategy-based example
+
+Use the built-in strategy factories for fine-grained control.
+
+```ts
+import {
+  findByScrolling,
+  ScrollStrategies,
+  EndStrategies,
+  MatchStrategies,
+} from '@rickcedwhat/playwright-sugar';
+
+await findByScrolling(page.getByText('Item #500'), {
+  container: page.locator('.virtual-list'),
+  scrollStrategy: ScrollStrategies.byPixels(300),
+  endStrategy: EndStrategies.noNewItems(),
+  matchStrategy: MatchStrategies.isVisible(),
+  maxAttempts: 100,
+  waitAfterStep: 150,
+});
+```

--- a/docs/api/outcomes.md
+++ b/docs/api/outcomes.md
@@ -1,0 +1,72 @@
+# Outcomes
+
+DSL for building outcome specs used by [`attemptAction`](/api/attempt-action) and [`Play.attempt()`](/api/play).
+
+## Outcomes.success
+
+```ts
+Outcomes.success(locator: LocatorArg): OutcomeSpec
+Outcomes.success(name: string, locator: LocatorArg, opts?: { onOutcome? }): OutcomeSpec
+```
+
+Marks an outcome as successful. `locator` can be a pre-bound `Locator` or a `(page, ctx) => Locator` function.
+
+```ts
+Outcomes.success(page.getByText('Saved'))
+Outcomes.success('created', page.getByText('Saved'))
+Outcomes.success(p => p.getByText('Saved'))
+Outcomes.success('created', (p, ctx) => p.getByText(ctx['expectedText'] as string))
+```
+
+## Outcomes.failure
+
+```ts
+Outcomes.failure(locator: LocatorArg): OutcomeSpec
+Outcomes.failure(name: string, locator: LocatorArg, opts?: { onOutcome? }): OutcomeSpec
+```
+
+Marks an outcome as a failure. Same locator forms as `success`.
+
+```ts
+Outcomes.failure(page.getByText('Permission denied'))
+Outcomes.failure('blocked', p => p.locator('[data-toast]').filter({ hasText: /failed/i }))
+```
+
+## Outcomes.timeout
+
+```ts
+Outcomes.timeout(): OutcomeSpec
+Outcomes.timeout(after: number): OutcomeSpec
+Outcomes.timeout(name: string, after?: number): OutcomeSpec
+```
+
+Resolves when no other outcome is detected within the allotted time. The `after` value (ms) is passed to `attemptAction` as the timeout.
+
+```ts
+Outcomes.timeout()               // default name 'timeout'
+Outcomes.timeout(8000)           // 8 s timeout
+Outcomes.timeout('rbac-missing', 5000)
+```
+
+## Outcomes.actionError
+
+```ts
+Outcomes.actionError(name?: string): OutcomeSpec
+```
+
+Resolves when the `action` function throws (e.g. a button was missing). Useful to distinguish a missing trigger from a true timeout.
+
+```ts
+Outcomes.actionError()
+Outcomes.actionError('button-missing')
+```
+
+## Locator arg
+
+All locator-bearing outcomes accept:
+
+| Form | When to use |
+|---|---|
+| `page.getByText('Done')` | Page is in scope (direct `attemptAction` usage) |
+| `p => p.getByText('Done')` | Inside `Play.attempt()` — page resolved at run time |
+| `(p, ctx) => p.getByText(ctx['label'] as string)` | Need Playbook context values |

--- a/docs/api/play.md
+++ b/docs/api/play.md
@@ -1,0 +1,105 @@
+# Play
+
+An immutable, chainable builder that describes a test scenario as a sequence of named steps. Each method returns a new `Play` — the original is unchanged.
+
+## Constructor
+
+```ts
+new Play()
+```
+
+## Step builders
+
+All builders accept an optional `ActOptions` as their last argument: `{ skip?: boolean }`.
+
+### .nav(fn, opts?)
+
+Navigation step — click a sidebar link, go to a URL. Logged as `nav`.
+
+```ts
+new Play().nav(async page => {
+  await page.getByRole('link', { name: 'Datasets' }).click();
+})
+```
+
+### .prep(fn, opts?)
+
+Setup step that runs before the attempt — open a menu, select a row. Logged as `prep`.
+
+### .reload(reloadOpts?, opts?)
+
+Reloads the page. Accepts the same options as Playwright's `page.reload()`.
+
+```ts
+new Play().reload({ waitUntil: 'domcontentloaded' }, { skip: !withReload })
+```
+
+### .detect(fn, opts?)
+
+Waits for one of several locators to appear and records the winner in `ctx.state`. Used for branching (e.g. determine whether a table is empty or populated).
+
+```ts
+new Play().detect(page => [
+  { name: 'empty',    isSuccess: true,  locator: page.getByText('No items') },
+  { name: 'hasItems', isSuccess: true,  locator: page.locator('tbody tr') },
+], { timeout: 8000 })
+```
+
+`ctx.state` is set to `{ name, isSuccess, data }` after detect runs.
+
+### .attempt(config, opts?)  /  .attempt(name, config, opts?)
+
+Performs an action and waits for an outcome.
+
+```ts
+new Play().attempt({
+  trigger: async (page, ctx) => {
+    const btn = ctx['state']?.name === 'empty' ? 'Empty item' : 'Item';
+    await page.getByRole('button', { name: btn }).click();
+    await page.getByPlaceholder('Name').fill('My Item');
+    await page.getByRole('button', { name: 'Create' }).click();
+  },
+  outcomes: [
+    Outcomes.success(p => p.getByText('Item created')),
+    Outcomes.failure(p => p.getByText('Permission denied')),
+    Outcomes.timeout(8000),
+  ],
+})
+```
+
+`ctx.result` is set to `{ isSuccess, outcome, data }` after the attempt.
+
+### .cleanup(fn, opts?)
+
+Runs after a successful attempt — typically reverts state so the test is idempotent. Skipped if the attempt was never reached or if a prior step threw.
+
+```ts
+new Play().cleanup(async (page, ctx) => {
+  if ((ctx.result as any)?.isSuccess) {
+    // revert the change
+  } else {
+    await page.keyboard.press('Escape');
+  }
+})
+```
+
+## Execution
+
+### .run(label, ctx)
+
+```ts
+play.run(label: string, ctx: PlayCtx): Promise<PlayCtx>
+```
+
+Executes all steps in order. Calls `page.bringToFront()` automatically. Logs each step with ✅ / ❌ / ⏭ and timing. Normally called by `Director` rather than directly.
+
+## Step context (PlayCtx)
+
+```ts
+type PlayCtx = {
+  page: Page;
+  state: { name: string; isSuccess: boolean; data?: unknown } | null;
+  result: { isSuccess: boolean; outcome: string; data?: unknown } | null;
+  [key: string]: unknown; // extra keys from Playbook.withCtx()
+}
+```

--- a/docs/api/playbook.md
+++ b/docs/api/playbook.md
@@ -30,7 +30,7 @@ Returns a new Playbook with merged context. The original is unchanged. Must be c
 ```ts
 const pb = datasetPb.withCtx({ page });
 // with extra context
-const pb = datasetPb.withCtx({ page, table: braintrustTable });
+const pbWithTable = datasetPb.withCtx({ page, table: braintrustTable });
 ```
 
 Extra keys are available in every act function via `ctx`:

--- a/docs/api/playbook.md
+++ b/docs/api/playbook.md
@@ -1,0 +1,55 @@
+# Playbook
+
+A named registry of play factories. Bind a `page` (and any extra context) with `.withCtx()` before passing to `Director`.
+
+## Constructor
+
+```ts
+new Playbook(name: string, plays: Record<string, (params: any) => Play>)
+new Playbook(plays: Record<string, (params: any) => Play>)
+```
+
+```ts
+const datasetPb = new Playbook('DatasetPlaybook', {
+  exists: ({ name }) => new Play()
+    .nav(async page => { await page.getByRole('button', { name: 'Datasets' }).click(); })
+    .detect(page => [
+      { name: 'found',    isSuccess: true,  locator: page.locator(`tr:has-text("${name}")`) },
+      { name: 'notFound', isSuccess: false, locator: page.getByText('No datasets') },
+    ]),
+
+  create: ({ name }) => new Play()
+    // ...
+});
+```
+
+## .withCtx(ctx)
+
+Returns a new Playbook with merged context. The original is unchanged. Must be called with at least `{ page }` before using `Director`.
+
+```ts
+const pb = datasetPb.withCtx({ page });
+// with extra context
+const pb = datasetPb.withCtx({ page, table: braintrustTable });
+```
+
+Extra keys are available in every act function via `ctx`:
+
+```ts
+.nav(async (page, ctx) => {
+  const table = ctx['table'] as BraintrustTable;
+  // ...
+})
+```
+
+## .getPlay(name)
+
+Returns the play factory for the given name. Throws if the play doesn't exist.
+
+## .getPage()
+
+Returns the bound page. Throws if `.withCtx({ page })` has not been called.
+
+## .buildCtx()
+
+Returns an initial `PlayCtx` from the bound context with `state` and `result` initialised to `null`. Called internally by `Director`.

--- a/docs/api/relator.md
+++ b/docs/api/relator.md
@@ -1,0 +1,61 @@
+# relator
+
+Finds a target element that is semantically related to a unique anchor element. Solves the problem of selecting "the Edit button in *this* row" without relying on fragile nth-child or data-testid selectors.
+
+## Signature
+
+```ts
+relator(
+  anchor: Locator,
+  target: Locator,
+  container?: string | Locator
+): Locator
+```
+
+| Parameter | Description |
+|---|---|
+| `anchor` | A unique element that identifies the context (e.g. row text, card heading). |
+| `target` | The element you want to interact with (e.g. a button, an input). |
+| `container` | Optional. A CSS selector or Locator for the shared parent. If omitted, `relator` finds the innermost element containing both. |
+
+Returns a standard Playwright `Locator` — all Playwright methods work on it.
+
+## Examples
+
+### With an explicit container
+
+```ts
+import { relator } from '@rickcedwhat/playwright-sugar';
+
+// Click "Edit" only in the row containing "Invoice #42"
+const editBtn = relator(
+  page.getByText('Invoice #42'),
+  page.getByRole('button', { name: 'Edit' }),
+  'tr'
+);
+await editBtn.click();
+```
+
+### Automatic mode (no container)
+
+`relator` walks the DOM to find the innermost element that contains both the anchor and the target.
+
+```ts
+// Click "Buy" only in the "Pro Plan" card
+const buyBtn = relator(
+  page.getByText('Pro Plan'),
+  page.getByRole('button', { name: 'Buy' })
+);
+await buyBtn.click();
+```
+
+### Filling a scoped input
+
+```ts
+const statusInput = relator(
+  page.getByText('User #2'),
+  page.locator('input.status'),
+  'div.row'
+);
+await statusInput.fill('Active');
+```

--- a/docs/api/sync-strategy.md
+++ b/docs/api/sync-strategy.md
@@ -1,0 +1,41 @@
+# SyncStrategy
+
+Describes how to synchronise state to a second page after `Director.ensureExists` creates a resource. Passed as `syncStrategy` in `ensureExists` options.
+
+## SyncStrategy.default()
+
+No-op sync. `bringToFront` is handled automatically by `Play.run()`, and the `exists` play handles its own navigation. Use this (or omit `syncStrategy`) when the second page polls or subscribes to updates automatically.
+
+```ts
+await director.ensureExists(adminPb, params, { syncTo: viewerPage });
+// equivalent to:
+await director.ensureExists(adminPb, params, {
+  syncTo: viewerPage,
+  syncStrategy: SyncStrategy.default(),
+});
+```
+
+## SyncStrategy.withReload()
+
+Reloads the sync target page (`waitUntil: 'domcontentloaded'`) before retrying `exists`. Use when the second page reads from localStorage or a polling endpoint that updates on page load.
+
+```ts
+await director.ensureExists(adminPb, params, {
+  syncTo: viewerPage,
+  syncStrategy: SyncStrategy.withReload(),
+});
+```
+
+## SyncStrategy.custom(fn)
+
+User-defined sync logic.
+
+```ts
+await director.ensureExists(adminPb, params, {
+  syncTo: viewerPage,
+  syncStrategy: SyncStrategy.custom(async page => {
+    await page.evaluate(() => window.__refreshData());
+    await page.waitForResponse('/api/datasets');
+  }),
+});
+```

--- a/docs/api/verified-fill.md
+++ b/docs/api/verified-fill.md
@@ -1,0 +1,35 @@
+# verifiedFill
+
+Fills an input and verifies that the value actually stuck. Handles cases where React or Vue state lag causes the input to revert to its previous value after `fill`.
+
+## Signature
+
+```ts
+verifiedFill(
+  locator: Locator,
+  value: string,
+  params?: { validate?: boolean; timeout?: number }
+): Promise<void>
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `validate` | `true` | Whether to assert the input value after filling. |
+| `timeout` | `5000` | How long to wait for the value to stabilise (ms). |
+
+## Example
+
+```ts
+import { verifiedFill } from '@rickcedwhat/playwright-sugar';
+
+await verifiedFill(page.getByLabel('Email'), 'user@example.com');
+// throws if the input value is not 'user@example.com' after filling
+```
+
+## When to use
+
+Standard `locator.fill()` is sufficient for most inputs. Use `verifiedFill` when:
+
+- The field has a controlled React component that resets on every keystroke.
+- An autocomplete or mask intercepts the input and transforms the value.
+- A slow network request triggers a re-render that clears the field.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,0 +1,97 @@
+# Getting Started
+
+## Installation
+
+```bash
+npm install -D @rickcedwhat/playwright-sugar
+# or
+pnpm add -D @rickcedwhat/playwright-sugar
+```
+
+## Quick start
+
+### Handling RBAC and toast outcomes
+
+Use `attemptAction` when an action can produce multiple outcomes — success, failure toast, or a missing button — and you want to branch on the result rather than let Playwright throw.
+
+```ts
+import { attemptAction, Outcomes } from '@rickcedwhat/playwright-sugar';
+
+const result = await attemptAction({
+  action: async () => {
+    await page.getByRole('button', { name: 'Delete' }).click();
+  },
+  outcomes: [
+    Outcomes.success(page.getByText('Deleted successfully')),
+    Outcomes.failure(page.getByText('Permission denied')),
+    Outcomes.timeout(5000),
+  ],
+});
+
+if (result.isSuccess) {
+  // item was deleted
+}
+```
+
+### Structured test scenarios with Play and Director
+
+`Play` lets you describe a test scenario as a sequence of named steps. `Director` runs plays and makes assertions about whether they succeeded or failed — useful for RBAC testing.
+
+```ts
+import { Play, Playbook, Director, Outcomes } from '@rickcedwhat/playwright-sugar';
+
+const itemPb = new Playbook('ItemPlaybook', {
+  exists: ({ name }) => new Play()
+    .nav(async page => { await page.getByRole('link', { name: 'Items' }).click(); })
+    .detect(page => [
+      { name: 'found',    isSuccess: true,  locator: page.locator(`tr:has-text("${name}")`) },
+      { name: 'notFound', isSuccess: false, locator: page.getByText('No items') },
+    ]),
+
+  create: ({ name }) => new Play()
+    .nav(async page => { await page.getByRole('link', { name: 'Items' }).click(); })
+    .attempt({
+      trigger: async page => {
+        await page.getByRole('button', { name: 'New item' }).click();
+        await page.getByPlaceholder('Name').fill(name);
+        await page.getByRole('button', { name: 'Create' }).click();
+      },
+      outcomes: [
+        Outcomes.success(page => page.getByText('Item created')),
+        Outcomes.failure(page => page.getByText('Permission denied')),
+        Outcomes.timeout(8000),
+      ],
+    }),
+});
+
+test('admin can create item', async ({ page }) => {
+  const director = new Director();
+  const pb = itemPb.withCtx({ page });
+
+  await director.assertCan(pb, 'create', { name: 'My Item' });
+});
+
+test('viewer cannot create item', async ({ page }) => {
+  await page.goto('/?role=viewer');
+  const director = new Director();
+  const pb = itemPb.withCtx({ page });
+
+  await director.assertCannot(pb, 'create', { name: 'Blocked Item' });
+});
+```
+
+### Stable locators with relator
+
+Use `relator` to find an element relative to a unique anchor — avoids fragile nth-child selectors.
+
+```ts
+import { relator } from '@rickcedwhat/playwright-sugar';
+
+// Click the "Edit" button in the row that contains "Invoice #42"
+const editBtn = relator(
+  page.getByText('Invoice #42'),
+  page.getByRole('button', { name: 'Edit' }),
+  'tr'
+);
+await editBtn.click();
+```

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -38,6 +38,7 @@ if (result.isSuccess) {
 `Play` lets you describe a test scenario as a sequence of named steps. `Director` runs plays and makes assertions about whether they succeeded or failed — useful for RBAC testing.
 
 ```ts
+import { test } from '@playwright/test';
 import { Play, Playbook, Director, Outcomes } from '@rickcedwhat/playwright-sugar';
 
 const itemPb = new Playbook('ItemPlaybook', {

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,11 +18,13 @@ hero:
 
 features:
   - title: Soft Triggers
-    details: Handle RBAC, Toasts, and optional UI elements with the `attemptAction` engine.
+    details: "Handle RBAC, toasts, and optional UI elements with the attemptAction engine."
   - title: Semantic Locators
-    details: Use `relator` to find elements based on their relationship to semantic ancestors.
+    details: "Use relator to find elements based on their relationship to semantic ancestors."
   - title: Verified Inputs
-    details: `verifiedFill` ensures your inputs actually stick in high-state modern apps.
+    details: "verifiedFill ensures your inputs actually stick in high-state modern apps."
   - title: Smart Scrolling
-    details: Strategy-based search for virtualized and infinite-scroll lists.
+    details: "Strategy-based search for virtualized and infinite-scroll lists."
+  - title: Director API
+    details: "Play, Playbook, and Director — structured RBAC tests and fixture setup with full logging."
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rickcedwhat/playwright-sugar",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "packageManager": "pnpm@10.33.2",
   "description": "Sugar for Playwright: Branching logic, automatic relators, and stable clicks.",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Adds a full VitePress documentation site covering every public API
- Deploys to GitHub Pages at `https://rickcedwhat.github.io/playwright-sugar/` on every `v*` tag push
- Bumps version to `0.2.0`

## Pages added

**Guide**
- Getting Started — install, `attemptAction` quick-start, `Director` + `Playbook` quick-start

**Core Helpers**
- `attemptAction`, `Outcomes`, `relator`, `verifiedFill`, `clickToOpen`, `findByScrolling`

**Director API**
- `Play`, `Playbook`, `Director`, `SyncStrategy`

## Deploy trigger

`.github/workflows/deploy-docs.yml` fires on `v*` tag pushes. To ship the docs after merging:

```bash
git tag v0.2.0 && git push origin v0.2.0
```

GitHub Pages source must be set to **GitHub Actions** in repo settings (Settings → Pages → Source).

## Notes

- `base: '/playwright-sugar/'` set in VitePress config for correct asset paths on GH Pages
- Home page `features` list updated to include the Director API and fixed YAML quoting issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – v0.2.0

* **New Features**
  * Introduced scenario-based testing framework: `Play`, `Playbook`, and `Director` for structured test cases and RBAC assertions
  * Added `attemptAction` for safe branching on test outcomes without throwing
  * New helpers: `findByScrolling`, `clickToOpen`, `verifiedFill`, and `relator` for robust element interaction
  * Introduced `Outcomes` DSL and `SyncStrategy` for flexible test outcome definitions

* **Documentation**
  * Comprehensive API documentation for all new features
  * Added getting started guide with usage examples
  * Documentation now auto-deployed to GitHub Pages on version releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->