### PR TITLE
ci: deploy docs on push to main

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,8 +2,8 @@ name: Deploy Docs
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
Changes the docs deploy trigger from `push: tags: v*` to `push: branches: main` so docs redeploy automatically on every merged PR — no manual tag push needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)