### PR TITLE
feat(play): positional attempt() API

### DIFF
--- a/docs/api/play.md
+++ b/docs/api/play.md
@@ -10,7 +10,7 @@ new Play()
 
 ## Step builders
 
-All builders accept an optional `ActOptions` as their last argument: `{ skip?: boolean }`.
+All builders except `.attempt()` accept an optional `ActOptions` as their last argument: `{ skip?: boolean }`.
 
 ### .nav(fn, opts?)
 
@@ -47,27 +47,57 @@ new Play().detect(page => [
 
 `ctx.state` is set to `{ name, isSuccess, data }` after detect runs.
 
-### .attempt(config, opts?)  /  .attempt(name, config, opts?)
+### .attempt(trigger, outcomes, timeout?)  /  .attempt(name, trigger, outcomes, timeout?)
 
 Performs an action and waits for an outcome.
 
+**Unnamed attempt** (logged as `attempt`):
+
 ```ts
-new Play().attempt({
-  trigger: async (page, ctx) => {
+new Play().attempt(
+  async (page, ctx) => {
     const btn = ctx['state']?.name === 'empty' ? 'Empty item' : 'Item';
     await page.getByRole('button', { name: btn }).click();
     await page.getByPlaceholder('Name').fill('My Item');
     await page.getByRole('button', { name: 'Create' }).click();
   },
-  outcomes: [
+  [
     Outcomes.success(p => p.getByText('Item created')),
     Outcomes.failure(p => p.getByText('Permission denied')),
     Outcomes.timeout(8000),
   ],
-})
+)
+```
+
+**Named attempt** (logged under the given name, e.g. for clearer errors):
+
+```ts
+new Play().attempt(
+  'submit',
+  async page => {
+    await page.getByRole('button', { name: 'Save' }).click();
+  },
+  [
+    Outcomes.success(page => page.getByText('Saved')),
+    Outcomes.failure(page => page.getByText('Validation failed')),
+    Outcomes.timeout(5000),
+  ],
+)
 ```
 
 `ctx.result` is set to `{ isSuccess, outcome, data }` after the attempt.
+
+#### Timeout semantics
+
+Timeouts are resolved in this order:
+
+1. **Positional `timeout`** (third argument on the unnamed overload, fourth on the named overload): passed through to `attemptAction` as the polling budget. If no locator outcome wins before this limit **and** there is **no** `Outcomes.timeout()` outcome in the list, `attemptAction` throws (hard timeout).
+
+2. **`Outcomes.timeout(after)`** (soft timeout outcome): supplies an `after` value used as the polling budget **when** no explicit positional timeout is provided. If the timer expires without another locator winning, the winner is the timeout **outcome** — resolution completes normally and `ctx.result` reflects that outcome (typically `isSuccess: false`), rather than throwing.
+
+3. **Default** (30 seconds): used when neither a positional timeout nor a timeout outcome with an `after` value applies.
+
+Whether expiry throws or returns a named outcome depends on your outcome list: include `Outcomes.timeout(...)` when you want a soft, named timeout path; rely on positional timeout alone when unmatched states should fail the step with an error.
 
 ### .cleanup(fn, opts?)
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -51,18 +51,18 @@ const itemPb = new Playbook('ItemPlaybook', {
 
   create: ({ name }) => new Play()
     .nav(async page => { await page.getByRole('link', { name: 'Items' }).click(); })
-    .attempt({
-      trigger: async page => {
+    .attempt(
+      async page => {
         await page.getByRole('button', { name: 'New item' }).click();
         await page.getByPlaceholder('Name').fill(name);
         await page.getByRole('button', { name: 'Create' }).click();
       },
-      outcomes: [
+      [
         Outcomes.success(page => page.getByText('Item created')),
         Outcomes.failure(page => page.getByText('Permission denied')),
         Outcomes.timeout(8000),
       ],
-    }),
+    ),
 });
 
 test('admin can create item', async ({ page }) => {

--- a/src/play.test.ts
+++ b/src/play.test.ts
@@ -78,10 +78,7 @@ describe('Play chain order', () => {
     const play = new Play()
       .nav(async () => { names.push('nav'); })
       .prep(async () => { names.push('prep'); })
-      .attempt({
-        trigger: async () => {},
-        outcomes: [Outcomes.success(mockLocator)],
-      });
+      .attempt(async () => {}, [Outcomes.success(mockLocator)]);
 
     await play.run('label', { page, state: null, result: null });
 
@@ -204,7 +201,7 @@ describe('.attempt() and .cleanup()', () => {
     mockAttemptAction.mockResolvedValueOnce({ isSuccess: true, outcome: 'ok', data: undefined });
 
     const play = new Play()
-      .attempt({ trigger: async () => {}, outcomes: [Outcomes.success(mockLocator)] })
+      .attempt(async () => {}, [Outcomes.success(mockLocator)])
       .cleanup(cleanupFn);
 
     await play.run('label', { page, state: null, result: null });
@@ -218,7 +215,7 @@ describe('.attempt() and .cleanup()', () => {
     mockAttemptAction.mockResolvedValueOnce({ isSuccess: false, outcome: 'fail', data: undefined });
 
     const play = new Play()
-      .attempt({ trigger: async () => {}, outcomes: [Outcomes.failure(mockLocator)] })
+      .attempt(async () => {}, [Outcomes.failure(mockLocator)])
       .cleanup(cleanupFn);
 
     await play.run('label', { page, state: null, result: null });
@@ -232,7 +229,7 @@ describe('.attempt() and .cleanup()', () => {
     mockAttemptAction.mockResolvedValueOnce({ isSuccess: false, outcome: 'blocked', data: undefined });
 
     const play = new Play()
-      .attempt({ trigger: async () => {}, outcomes: [Outcomes.failure(mockLocator)] })
+      .attempt(async () => {}, [Outcomes.failure(mockLocator)])
       .cleanup(async (_p, ctx) => { seenResult = ctx['result']; });
 
     await play.run('label', { page, state: null, result: null });
@@ -245,7 +242,7 @@ describe('.attempt() and .cleanup()', () => {
     mockAttemptAction.mockResolvedValueOnce({ isSuccess: true, outcome: 'created', data: 42 });
 
     const play = new Play()
-      .attempt({ trigger: async () => {}, outcomes: [Outcomes.success(mockLocator)] });
+      .attempt(async () => {}, [Outcomes.success(mockLocator)]);
 
     const ctx = await play.run('label', { page, state: null, result: null });
 
@@ -286,10 +283,7 @@ describe('error labels', () => {
     const page = makePage();
     mockAttemptAction.mockRejectedValueOnce(new Error('attempt failed'));
 
-    const play = new Play().attempt('submit', {
-      trigger: async () => {},
-      outcomes: [Outcomes.success(mockLocator)],
-    });
+    const play = new Play().attempt('submit', async () => {}, [Outcomes.success(mockLocator)]);
 
     await expect(play.run('Pb > play', { page, state: null, result: null }))
       .rejects.toThrow('[Pb > play > submit]');
@@ -310,10 +304,9 @@ describe('.attempt() locator resolution', () => {
       return { isSuccess: true, outcome: 'success', data: undefined };
     });
 
-    const play = new Play().attempt({
-      trigger: async () => {},
-      outcomes: [Outcomes.success(p => p.getByText('This dataset is empty'))],
-    });
+    const play = new Play().attempt(async () => {}, [
+      Outcomes.success(p => p.getByText('This dataset is empty')),
+    ]);
 
     await play.run('label', { page, state: null, result: null });
 
@@ -330,10 +323,9 @@ describe('.attempt() locator resolution', () => {
       ({ isSuccess: true, outcome: 'success', data: undefined })
     );
 
-    const play = new Play().attempt({
-      trigger: async () => {},
-      outcomes: [Outcomes.success((_p, ctx) => { capturedCtx = ctx; return _p.getByText('test'); })],
-    });
+    const play = new Play().attempt(async () => {}, [
+      Outcomes.success((_p, ctx) => { capturedCtx = ctx; return _p.getByText('test'); }),
+    ]);
 
     await play.run('label', { page, state: null, result: null });
 
@@ -349,17 +341,53 @@ describe('.attempt() locator resolution', () => {
       return { isSuccess: true, outcome: 'ok', data: undefined };
     });
 
-    const play = new Play().attempt({
-      trigger: async () => {},
-      outcomes: [
-        Outcomes.success(p => p.getByText('done')),
-        Outcomes.timeout(8000),
-      ],
-    });
+    const play = new Play().attempt(async () => {}, [
+      Outcomes.success(p => p.getByText('done')),
+      Outcomes.timeout(8000),
+    ]);
 
     await play.run('label', { page, state: null, result: null });
 
     expect(capturedTimeout).toBe(8000);
+  });
+
+  it('passes positional timeout as the third argument to attemptAction', async () => {
+    const page = makePage();
+    let capturedTimeout: unknown;
+    mockAttemptAction.mockImplementationOnce(async ({ timeout }) => {
+      capturedTimeout = timeout;
+      return { isSuccess: true, outcome: 'ok', data: undefined };
+    });
+
+    const play = new Play().attempt(
+      async () => {},
+      [Outcomes.success(p => p.getByText('done')), Outcomes.timeout(9999)],
+      12_000
+    );
+
+    await play.run('label', { page, state: null, result: null });
+
+    expect(capturedTimeout).toBe(12_000);
+  });
+
+  it('uses named overload with positional timeout', async () => {
+    const page = makePage();
+    let capturedTimeout: unknown;
+    mockAttemptAction.mockImplementationOnce(async ({ timeout }) => {
+      capturedTimeout = timeout;
+      return { isSuccess: true, outcome: 'ok', data: undefined };
+    });
+
+    const play = new Play().attempt(
+      'named-step',
+      async () => {},
+      [Outcomes.success(mockLocator)],
+      7000
+    );
+
+    await play.run('label', { page, state: null, result: null });
+
+    expect(capturedTimeout).toBe(7000);
   });
 });
 
@@ -513,10 +541,7 @@ describe('Play logging', () => {
     const page = makePage();
     mockAttemptAction.mockResolvedValueOnce({ isSuccess: false, outcome: 'blocked', data: undefined });
 
-    const play = new Play().attempt({
-      trigger: async () => {},
-      outcomes: [Outcomes.failure(mockLocator)],
-    });
+    const play = new Play().attempt(async () => {}, [Outcomes.failure(mockLocator)]);
 
     await play.run('label', { page, state: null, result: null });
 
@@ -550,7 +575,7 @@ describe('Play logging', () => {
     mockAttemptAction.mockResolvedValueOnce({ isSuccess: true, outcome: 'ok', data: undefined });
 
     const play = new Play()
-      .attempt({ trigger: async () => {}, outcomes: [Outcomes.success(mockLocator)] })
+      .attempt(async () => {}, [Outcomes.success(mockLocator)])
       .act('post', async () => { throw new Error('after attempt'); })
       .cleanup(async () => {});
 

--- a/src/play.ts
+++ b/src/play.ts
@@ -31,19 +31,18 @@ type DetectCandidate = {
   locator?: import('@playwright/test').Locator;
 };
 
-type AttemptConfig = {
-  trigger: ActFn;
-  outcomes: OutcomeSpec[];
-  /** Optional explicit timeout. If omitted, Play derives it from the timeout outcome's .after field. */
-  timeout?: number;
-};
-
 // ── Internal act record (discriminated union) ─────────────────────────────────
 
 type ActRecord =
   | { kind: 'act'; name: string; fn: ActFn; skip: boolean }
   | { kind: 'detect'; fn: (page: Page) => DetectCandidate[]; timeout?: number; skip: boolean }
-  | { kind: 'attempt'; name: string; config: AttemptConfig; skip: boolean }
+  | {
+      kind: 'attempt';
+      name: string;
+      trigger: ActFn;
+      outcomes: OutcomeSpec[];
+      timeout?: number;
+    }
   | { kind: 'cleanup'; fn: ActFn; skip: boolean }
   | { kind: 'reload'; opts: Parameters<Page['reload']>[0] | undefined; skip: boolean };
 
@@ -87,20 +86,39 @@ export class Play {
     });
   }
 
-  attempt(config: AttemptConfig, opts?: ActOptions): Play;
-  attempt(name: string, config: AttemptConfig, opts?: ActOptions): Play;
+  attempt(trigger: ActFn, outcomes: OutcomeSpec[], timeout?: number): Play;
+  attempt(name: string, trigger: ActFn, outcomes: OutcomeSpec[], timeout?: number): Play;
   attempt(
-    nameOrConfig: string | AttemptConfig,
-    configOrOpts?: AttemptConfig | ActOptions,
-    opts?: ActOptions
+    nameOrTrigger: string | ActFn,
+    triggerOrOutcomes: ActFn | OutcomeSpec[],
+    outcomesOrTimeout?: OutcomeSpec[] | number,
+    maybeTimeout?: number
   ): Play {
-    if (typeof nameOrConfig === 'string') {
-      const config = configOrOpts as AttemptConfig;
-      return this._append({ kind: 'attempt', name: nameOrConfig, config, skip: opts?.skip ?? false });
+    if (typeof nameOrTrigger === 'string') {
+      const name = nameOrTrigger;
+      const trigger = triggerOrOutcomes as ActFn;
+      const outcomes = outcomesOrTimeout as OutcomeSpec[];
+      const timeout = maybeTimeout;
+      return this._append({
+        kind: 'attempt',
+        name,
+        trigger,
+        outcomes,
+        ...(timeout !== undefined && { timeout }),
+      });
     }
-    const config = nameOrConfig;
-    const options = configOrOpts as ActOptions | undefined;
-    return this._append({ kind: 'attempt', name: 'attempt', config, skip: options?.skip ?? false });
+
+    const trigger = nameOrTrigger as ActFn;
+    const outcomes = triggerOrOutcomes as OutcomeSpec[];
+    const timeout = typeof outcomesOrTimeout === 'number' ? outcomesOrTimeout : undefined;
+
+    return this._append({
+      kind: 'attempt',
+      name: 'attempt',
+      trigger,
+      outcomes,
+      ...(timeout !== undefined && { timeout }),
+    });
   }
 
   cleanup(fn: ActFn, opts: ActOptions = {}): Play {
@@ -125,7 +143,7 @@ export class Play {
     for (const act of mainActs) {
       const actName = _actLabel(act);
 
-      if (act.skip || runError) {
+      if (runError || (act.kind !== 'attempt' && act.skip)) {
         console.log(`  ⏭  ${actName}  SKIPPED`);
         continue;
       }
@@ -161,7 +179,7 @@ export class Play {
 
           case 'attempt': {
             attemptReached = true;
-            const resolvedOutcomes: Outcome[] = act.config.outcomes.map(o => ({
+            const resolvedOutcomes: Outcome[] = act.outcomes.map(o => ({
               name: o.name,
               isSuccess: o.isSuccess,
               ...(o.isTimeoutOutcome && { isTimeoutOutcome: true }),
@@ -172,13 +190,13 @@ export class Play {
               }),
             }));
 
-            const timeoutOutcome = act.config.outcomes.find(o => o.isTimeoutOutcome);
+            const timeoutOutcome = act.outcomes.find(o => o.isTimeoutOutcome);
             const timeout =
-              act.config.timeout ??
+              act.timeout ??
               (timeoutOutcome?.after !== undefined ? timeoutOutcome.after : undefined);
 
             const attemptParams: Parameters<typeof attemptAction>[0] = {
-              action: () => act.config.trigger(page, ctx),
+              action: () => act.trigger(page, ctx),
               outcomes: resolvedOutcomes,
             };
             if (timeout !== undefined) attemptParams.timeout = timeout;

--- a/tests/director.spec.ts
+++ b/tests/director.spec.ts
@@ -26,20 +26,20 @@ const datasetPb = new Playbook('DatasetPlaybook', {
       { name: 'empty', isSuccess: true, locator: page.getByRole('button', { name: 'Empty dataset' }) },
       { name: 'table', isSuccess: true, locator: page.locator('[data-component="TableHeadersComponent"]') },
     ], { timeout: 8000 })
-    .attempt({
-      trigger: async (page, ctx) => {
+    .attempt(
+      async (page, ctx) => {
         const state = ctx['state'] as { name: string } | null;
         const btnName = state?.name === 'empty' ? 'Empty dataset' : 'Dataset';
         await page.getByRole('button', { name: btnName, exact: true }).click();
         await page.getByPlaceholder('Name').fill(name, { timeout: 3000 });
         await page.getByRole('button', { name: 'Create' }).click();
       },
-      outcomes: [
+      [
         Outcomes.success(page => page.getByText('This dataset is empty')),
         Outcomes.failure(page => page.locator('li[data-sonner-toast]').filter({ hasText: /Failed to/i })),
         Outcomes.timeout(10_000),
       ],
-    }),
+    ),
 
   update: ({ name, newName }: UpdateParams) => new Play()
     .nav(async page => { await page.getByRole('button', { name: 'Datasets' }).click(); })
@@ -47,18 +47,18 @@ const datasetPb = new Playbook('DatasetPlaybook', {
       await page.locator(`tr:has-text("${name}")`).getByRole('button', { name: 'Row actions' }).click();
       await page.getByRole('menuitem', { name: 'Rename' }).click();
     })
-    .attempt({
-      trigger: async page => {
+    .attempt(
+      async page => {
         // For viewer: no textbox appears (rename blocked by role check), trigger fails softly
         await page.getByRole('textbox').fill(newName, { timeout: 2000 });
         await page.getByRole('button', { name: 'Save' }).click();
       },
-      outcomes: [
+      [
         Outcomes.success(page => page.getByText('Updated dataset')),
         Outcomes.failure(page => page.locator('li[data-sonner-toast]').filter({ hasText: /Failed to/i })),
         Outcomes.timeout(5000),
       ],
-    })
+    )
     .cleanup(async (page, ctx) => {
       const result = ctx['result'] as { isSuccess: boolean } | null;
       if (result?.isSuccess) {


### PR DESCRIPTION
## Summary

- Replace config-object `attempt()` with positional overloads: `(trigger, outcomes, timeout?)` and `(name, trigger, outcomes, timeout?)`.
- Store `trigger`, `outcomes`, and optional `timeout` as top-level fields on attempt act records (default name `attempt` when unnamed); remove `ActOptions`/skip on attempts.
- Preserve timeout resolution: positional timeout → `Outcomes.timeout().after` → default 30s; soft vs hard timeout behavior unchanged via `isTimeoutOutcome` in `attemptAction`.
- Update unit tests (`play.test.ts`), integration playbook (`director.spec.ts`), and docs (`docs/api/play.md`, `docs/guide/getting-started.md`).

Closes #19

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `.attempt()` builder now accepts positional arguments (trigger function, outcomes array, optional timeout) or named syntax for improved clarity.

* **Documentation**
  * Updated Play API documentation with explicit method overload examples.
  * Added "Timeout semantics" section explaining timeout resolution behavior.
  * Revised getting-started guide with new `.attempt()` calling convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->