### PR TITLE
docs: add interactive Sugar Lab embeds

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     logo: '/logo.png',
     nav: [
       { text: 'Guide', link: '/guide/getting-started' },
+      { text: 'Sugar Lab', link: '/guide/sugar-lab' },
       { text: 'API', link: '/api/attempt-action' },
       { text: 'GitHub', link: 'https://github.com/rickcedwhat/playwright-sugar' }
     ],
@@ -16,6 +17,7 @@ export default defineConfig({
         text: 'Introduction',
         items: [
           { text: 'Getting Started', link: '/guide/getting-started' },
+          { text: 'Sugar Lab (live)', link: '/guide/sugar-lab' },
         ]
       },
       {

--- a/docs/.vitepress/theme/components/LabEmbed.vue
+++ b/docs/.vitepress/theme/components/LabEmbed.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = withDefaults(
+  defineProps<{
+    /** Query string without a leading `?`, e.g. `clear=1&role=viewer` */
+    query?: string;
+    /** Iframe height (px) */
+    height?: number;
+  }>(),
+  {
+    query: '',
+    height: 460,
+  }
+);
+
+const labOrigin = import.meta.env.VITE_LAB_ORIGIN ?? 'http://localhost:5173';
+
+const iframeSrc = computed(() => {
+  const base = labOrigin.replace(/\/$/, '');
+  const q = props.query.trim();
+  return q ? `${base}/?${q}` : `${base}/`;
+});
+</script>
+
+<template>
+  <div class="lab-embed vp-doc">
+    <iframe
+      class="lab-embed-frame"
+      :src="iframeSrc"
+      title="Sugar Lab"
+      loading="lazy"
+      referrerpolicy="no-referrer-when-downgrade"
+      :style="{ height: `${height}px` }"
+    />
+  </div>
+</template>
+
+<style scoped>
+.lab-embed {
+  margin: 1rem 0;
+}
+.lab-embed-frame {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  background: var(--vp-c-bg-soft);
+}
+</style>

--- a/docs/.vitepress/theme/components/LabEmbed.vue
+++ b/docs/.vitepress/theme/components/LabEmbed.vue
@@ -18,7 +18,7 @@ const labOrigin = import.meta.env.VITE_LAB_ORIGIN ?? 'http://localhost:5173';
 
 const iframeSrc = computed(() => {
   const base = labOrigin.replace(/\/$/, '');
-  const q = props.query.trim();
+  const q = props.query.trim().replace(/^\?+/, '');
   return q ? `${base}/?${q}` : `${base}/`;
 });
 </script>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,10 @@
+import DefaultTheme from 'vitepress/theme';
+import type { EnhanceAppContext } from 'vitepress';
+import LabEmbed from './components/LabEmbed.vue';
+
+export default {
+  extends: DefaultTheme,
+  enhanceApp({ app }: EnhanceAppContext) {
+    app.component('LabEmbed', LabEmbed);
+  },
+};

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -96,3 +96,7 @@ const editBtn = relator(
 );
 await editBtn.click();
 ```
+
+## Try the Sugar Lab
+
+The repo includes a small **Sugar Lab** app (Vite + React) used by integration tests. You can run it locally and follow [Sugar Lab (live)](/guide/sugar-lab) for embedded examples (`?role=viewer`, empty vs seeded data, and more).

--- a/docs/guide/sugar-lab.md
+++ b/docs/guide/sugar-lab.md
@@ -1,0 +1,74 @@
+# Sugar Lab playground
+
+The **Sugar Lab** is a small React app in the `lab/` directory. It powers the dataset flows used in [`tests/director.spec.ts`](https://github.com/rickcedwhat/playwright-sugar/blob/main/tests/director.spec.ts) — empty vs populated tables, admin vs viewer, toasts, and navigation.
+
+Run it locally (default URL `http://localhost:5173`):
+
+```bash
+pnpm --dir lab dev
+```
+
+In another terminal, run the docs site if you want both:
+
+```bash
+pnpm docs:dev
+```
+
+Embedded panels below load the lab in an iframe. They only work when the lab is reachable — typically **same machine, lab on port 5173**. For a deployed docs build, set `VITE_LAB_ORIGIN` at build time (see the note at the end).
+
+## Query parameters
+
+| Parameter | Effect |
+|-----------|--------|
+| `clear=1` | Clear persisted datasets (`localStorage`) before the app loads. |
+| `seed=<name>` | Append one dataset row (often paired with `clear=1`). |
+| `role=viewer` | Read-only user: create / rename / delete show failure toasts (matches integration tests). |
+| `view=settings` | Open the **Settings** screen instead of Datasets. |
+
+`role` is read from the URL on the Datasets page, so you can change behavior without reloading storage.
+
+---
+
+### Empty table (branching / “not found”)
+
+Use **`clear=1`** so the table starts empty — useful when explaining `.detect()` branches such as “no datasets” vs “row visible”.
+
+<LabEmbed query="clear=1" />
+
+Same URL in the address bar: `http://localhost:5173/?clear=1`
+
+---
+
+### Viewer role (failure toasts / `assertCannot`)
+
+**`clear=1&role=viewer`** — empty list; try **Empty dataset** / create flows and see permission toasts, aligned with `Outcomes.failure` + soft triggers in the library.
+
+<LabEmbed query="clear=1&role=viewer" />
+
+---
+
+### One seeded row (rename / row actions)
+
+**`clear=1&seed=Demo%20Dataset`** — reproducible single row for menus and rename without manual setup.
+
+<LabEmbed query="clear=1&seed=Demo%20Dataset" />
+
+---
+
+### Settings route (navigation target)
+
+**`view=settings`** — neutral page for sidebar / navigation examples.
+
+<LabEmbed query="view=settings" />
+
+---
+
+## Deployed docs and `VITE_LAB_ORIGIN`
+
+GitHub Pages builds for this repo currently publish **docs only**. If the iframe shows “connection refused”, start the lab locally or host the lab separately and rebuild docs with:
+
+```bash
+VITE_LAB_ORIGIN=https://your-lab-host.example pnpm docs:build
+```
+
+You can add a `docs/.env.production` (gitignored locally) with that variable for repeatable builds.

--- a/lab/README.md
+++ b/lab/README.md
@@ -18,6 +18,18 @@ Append `?role=viewer` to any URL to switch to viewer mode. In viewer mode, click
 http://localhost:5173/?role=viewer
 ```
 
+## URL presets (docs / iframes)
+
+These run **before** the first render so links and embedded demos are reproducible:
+
+| Param | Effect |
+|-------|--------|
+| `clear=1` | Remove persisted datasets (`sugar-lab-datasets`) so the list starts empty. |
+| `seed=<name>` | Append one dataset row (combine with `clear=1` for a single known row). |
+| `view=settings` | Open the Settings view instead of Datasets. |
+
+Example: `/?clear=1&seed=Demo&role=viewer`
+
 ## Scenarios
 
 ### Datasets page — Issue #10 (Playbook / Director)

--- a/lab/src/App.tsx
+++ b/lab/src/App.tsx
@@ -5,6 +5,7 @@ import DatasetsPage from './DatasetsPage';
 import DatasetDetailPage from './DatasetDetailPage';
 import SettingsPage from './SettingsPage';
 import LeaveDialog from './LeaveDialog';
+import { parseInitialRouteFromUrl } from './urlBootstrap';
 
 export type Dataset = { id: string; name: string };
 
@@ -27,7 +28,7 @@ function saveDatasets(datasets: Dataset[]) {
 
 export default function App() {
   const [datasets, setDatasets] = useState<Dataset[]>(loadDatasets);
-  const [route, setRoute] = useState<Route>({ view: 'datasets' });
+  const [route, setRoute] = useState<Route>(() => parseInitialRouteFromUrl());
   // true when the rename form is open — blocks navigation
   const [dirty, setDirty] = useState(false);
   const [pendingRoute, setPendingRoute] = useState<Route | null>(null);

--- a/lab/src/main.tsx
+++ b/lab/src/main.tsx
@@ -1,3 +1,7 @@
+import { applySugarLabUrlOverrides } from './urlBootstrap';
+
+applySugarLabUrlOverrides();
+
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';

--- a/lab/src/urlBootstrap.ts
+++ b/lab/src/urlBootstrap.ts
@@ -18,7 +18,8 @@ export function applySugarLabUrlOverrides(): void {
     const seed = p.get('seed')?.trim();
     if (seed) {
       const raw = localStorage.getItem('sugar-lab-datasets');
-      const rows: { id: string; name: string }[] = raw ? JSON.parse(raw) : [];
+      const parsed = raw ? JSON.parse(raw) : [];
+      const rows: { id: string; name: string }[] = Array.isArray(parsed) ? parsed : [];
       rows.push({ id: crypto.randomUUID(), name: seed });
       localStorage.setItem('sugar-lab-datasets', JSON.stringify(rows));
     }

--- a/lab/src/urlBootstrap.ts
+++ b/lab/src/urlBootstrap.ts
@@ -1,0 +1,40 @@
+/**
+ * Applies URL query overrides before React reads localStorage (iframe-friendly demos).
+ *
+ * Supported params:
+ * - `clear=1` — wipe persisted datasets
+ * - `seed=<name>` — append one dataset row (after optional clear)
+ * - `view=settings` — consumed by `parseInitialRouteFromUrl` in App
+ *
+ * `role=viewer` is read live from the URL in `DatasetsPage` (no bootstrap needed).
+ */
+export function applySugarLabUrlOverrides(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const p = new URLSearchParams(window.location.search);
+    if (p.get('clear') === '1') {
+      localStorage.removeItem('sugar-lab-datasets');
+    }
+    const seed = p.get('seed')?.trim();
+    if (seed) {
+      const raw = localStorage.getItem('sugar-lab-datasets');
+      const rows: { id: string; name: string }[] = raw ? JSON.parse(raw) : [];
+      rows.push({ id: crypto.randomUUID(), name: seed });
+      localStorage.setItem('sugar-lab-datasets', JSON.stringify(rows));
+    }
+  } catch {
+    // ignore malformed storage / JSON
+  }
+}
+
+type InitialRoute =
+  | { view: 'datasets' }
+  | { view: 'dataset-detail'; id: string }
+  | { view: 'settings' };
+
+export function parseInitialRouteFromUrl(): InitialRoute {
+  if (typeof window === 'undefined') return { view: 'datasets' };
+  const v = new URLSearchParams(window.location.search).get('view');
+  if (v === 'settings') return { view: 'settings' };
+  return { view: 'datasets' };
+}

--- a/src/play.ts
+++ b/src/play.ts
@@ -191,9 +191,7 @@ export class Play {
             }));
 
             const timeoutOutcome = act.outcomes.find(o => o.isTimeoutOutcome);
-            const timeout =
-              act.timeout ??
-              (timeoutOutcome?.after !== undefined ? timeoutOutcome.after : undefined);
+            const timeout = act.timeout ?? timeoutOutcome?.after;
 
             const attemptParams: Parameters<typeof attemptAction>[0] = {
               action: () => act.trigger(page, ctx),


### PR DESCRIPTION
## Summary
- Add a reusable VitePress `LabEmbed` component and a new `guide/sugar-lab` page with live iframe demos.
- Add URL bootstrap support in Sugar Lab (`clear`, `seed`, `view`) so docs examples are reproducible.
- Link the new guide from docs navigation and simplify `Play` timeout assignment (`act.timeout ?? timeoutOutcome?.after`).

## Validation
- `pnpm exec tsc`
- `pnpm exec vitest run`
- `pnpm docs:build`

Refs #19

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive Sugar Lab component embedded in documentation with support for URL query parameters (`clear`, `seed`, `view`, `role`) for reproducible demonstrations.

* **Documentation**
  * Added comprehensive Sugar Lab guide explaining local setup, embedded iframe usage, and URL parameter examples.
  * Updated getting-started guide with Sugar Lab reference.
  * Updated lab README with URL presets documentation.

* **Refactor**
  * Updated site navigation and configuration.
  * Enhanced Sugar Lab app with URL bootstrap functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->