### PR TITLE
docs: interactive Sugar Lab run-test sandbox

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     logo: '/logo.png',
     nav: [
       { text: 'Guide', link: '/guide/getting-started' },
+      { text: 'Sugar Lab', link: '/guide/sugar-lab' },
       { text: 'API', link: '/api/attempt-action' },
       { text: 'GitHub', link: 'https://github.com/rickcedwhat/playwright-sugar' }
     ],
@@ -16,6 +17,7 @@ export default defineConfig({
         text: 'Introduction',
         items: [
           { text: 'Getting Started', link: '/guide/getting-started' },
+          { text: 'Sugar Lab (live)', link: '/guide/sugar-lab' },
         ]
       },
       {

--- a/docs/.vitepress/theme/components/LabEmbed.vue
+++ b/docs/.vitepress/theme/components/LabEmbed.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = withDefaults(
+  defineProps<{
+    /** Query string without a leading `?`, e.g. `clear=1&role=viewer` */
+    query?: string;
+    /** Iframe height (px) */
+    height?: number;
+  }>(),
+  {
+    query: '',
+    height: 460,
+  }
+);
+
+const labOrigin = import.meta.env.VITE_LAB_ORIGIN ?? 'http://localhost:5173';
+
+const iframeSrc = computed(() => {
+  const base = labOrigin.replace(/\/$/, '');
+  const q = props.query.trim();
+  return q ? `${base}/?${q}` : `${base}/`;
+});
+</script>
+
+<template>
+  <div class="lab-embed vp-doc">
+    <iframe
+      class="lab-embed-frame"
+      :src="iframeSrc"
+      title="Sugar Lab"
+      loading="lazy"
+      referrerpolicy="no-referrer-when-downgrade"
+      :style="{ height: `${height}px` }"
+    />
+  </div>
+</template>
+
+<style scoped>
+.lab-embed {
+  margin: 1rem 0;
+}
+.lab-embed-frame {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  background: var(--vp-c-bg-soft);
+}
+</style>

--- a/docs/.vitepress/theme/components/LabEmbed.vue
+++ b/docs/.vitepress/theme/components/LabEmbed.vue
@@ -18,7 +18,7 @@ const labOrigin = import.meta.env.VITE_LAB_ORIGIN ?? 'http://localhost:5173';
 
 const iframeSrc = computed(() => {
   const base = labOrigin.replace(/\/$/, '');
-  const q = props.query.trim();
+  const q = props.query.trim().replace(/^\?+/, '');
   return q ? `${base}/?${q}` : `${base}/`;
 });
 </script>

--- a/docs/.vitepress/theme/components/RunTestSandbox.vue
+++ b/docs/.vitepress/theme/components/RunTestSandbox.vue
@@ -1,0 +1,120 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+
+type Role = 'admin' | 'user';
+type Action = 'create' | 'update' | 'delete';
+
+const role = ref<Role>('admin');
+const action = ref<Action>('create');
+const copied = ref(false);
+
+const grepBySelection: Record<Role, Record<Action, string>> = {
+  admin: {
+    create: 'assertCan: admin creates dataset from empty state',
+    update: 'assertCan: admin renames dataset, cleanup reverts the rename',
+    delete: 'assertCan: admin deletes dataset',
+  },
+  user: {
+    create: 'assertCannot: viewer cannot create dataset',
+    update: 'assertCannot: viewer cannot rename dataset, cleanup presses Escape',
+    delete: 'assertCannot: viewer cannot delete dataset',
+  },
+};
+
+const paramsByAction: Record<Action, string> = {
+  create: "{ name: 'My Dataset' }",
+  update: "{ name: 'Original Name', newName: 'Renamed' }",
+  delete: "{ name: 'Delete Me' }",
+};
+
+const playByAction: Record<Action, string> = {
+  create: 'create',
+  update: 'update',
+  delete: 'delete',
+};
+
+const labelByRole: Record<Role, string> = { admin: 'assertCan', user: 'assertCannot' };
+const urlRoleByRole: Record<Role, string> = { admin: '', user: 'role=viewer&' };
+const seedByAction: Record<Action, string> = {
+  create: '',
+  update: 'seed=Original%20Name&',
+  delete: 'seed=Delete%20Me&',
+};
+
+const labQuery = computed(
+  () => `${urlRoleByRole[role.value]}clear=1&${seedByAction[action.value]}`.replace(/&$/, '')
+);
+
+const runCommand = computed(
+  () =>
+    `pnpm test tests/director.spec.ts --grep "${grepBySelection[role.value][action.value]}"`
+);
+
+const codeSnippet = computed(() => {
+  const assertion = labelByRole[role.value];
+  const playName = playByAction[action.value];
+  const roleSetup = role.value === 'user' ? "await page.goto('/?role=viewer');\n" : '';
+  return [
+    "const director = new Director();",
+    "const adminPage = page;",
+    "const userPage = page;",
+    roleSetup + "const pb = datasetPb.withCtx({ page: " + (role.value === 'admin' ? 'adminPage' : 'userPage') + " });",
+    `await director.${assertion}(pb, '${playName}', ${paramsByAction[action.value]});`,
+  ].join('\n');
+});
+
+async function copyCommand(): Promise<void> {
+  await navigator.clipboard.writeText(runCommand.value);
+  copied.value = true;
+  setTimeout(() => { copied.value = false; }, 1200);
+}
+</script>
+
+<template>
+  <div class="sandbox-wrap">
+    <div class="controls">
+      <div class="group">
+        <button class="chip" :class="{ active: role === 'admin' }" @click="role = 'admin'">adminPage</button>
+        <button class="chip" :class="{ active: role === 'user' }" @click="role = 'user'">userPage</button>
+      </div>
+      <div class="group">
+        <button class="chip" :class="{ active: action === 'create' }" @click="action = 'create'">create</button>
+        <button class="chip" :class="{ active: action === 'update' }" @click="action = 'update'">update</button>
+        <button class="chip" :class="{ active: action === 'delete' }" @click="action = 'delete'">delete</button>
+      </div>
+    </div>
+
+    <LabEmbed :query="labQuery" :height="430" />
+
+    <p><strong>Snippet (updates with your selection):</strong></p>
+    <pre><code>{{ codeSnippet }}</code></pre>
+
+    <p><strong>Run this test:</strong> <code>{{ runCommand }}</code></p>
+    <button class="run-btn" @click="copyCommand">{{ copied ? 'Copied' : 'Run this test (copy command)' }}</button>
+  </div>
+</template>
+
+<style scoped>
+.sandbox-wrap { margin-top: 12px; }
+.controls { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 12px; }
+.group { display: flex; gap: 8px; }
+.chip {
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 16px;
+  padding: 6px 12px;
+  background: var(--vp-c-bg-soft);
+  cursor: pointer;
+}
+.chip.active {
+  border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-brand-1);
+}
+.run-btn {
+  border: 1px solid var(--vp-c-brand-1);
+  border-radius: 8px;
+  padding: 8px 12px;
+  background: transparent;
+  color: var(--vp-c-brand-1);
+  cursor: pointer;
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,10 @@
+import DefaultTheme from 'vitepress/theme';
+import type { EnhanceAppContext } from 'vitepress';
+import LabEmbed from './components/LabEmbed.vue';
+
+export default {
+  extends: DefaultTheme,
+  enhanceApp({ app }: EnhanceAppContext) {
+    app.component('LabEmbed', LabEmbed);
+  },
+};

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,10 +1,12 @@
 import DefaultTheme from 'vitepress/theme';
 import type { EnhanceAppContext } from 'vitepress';
 import LabEmbed from './components/LabEmbed.vue';
+import RunTestSandbox from './components/RunTestSandbox.vue';
 
 export default {
   extends: DefaultTheme,
   enhanceApp({ app }: EnhanceAppContext) {
     app.component('LabEmbed', LabEmbed);
+    app.component('RunTestSandbox', RunTestSandbox);
   },
 };

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -96,3 +96,7 @@ const editBtn = relator(
 );
 await editBtn.click();
 ```
+
+## Try the Sugar Lab
+
+The repo includes a small **Sugar Lab** app (Vite + React) used by integration tests. You can run it locally and follow [Sugar Lab (live)](/guide/sugar-lab) for embedded examples (`?role=viewer`, empty vs seeded data, and more).

--- a/docs/guide/sugar-lab.md
+++ b/docs/guide/sugar-lab.md
@@ -1,74 +1,35 @@
 # Sugar Lab playground
 
-The **Sugar Lab** is a small React app in the `lab/` directory. It powers the dataset flows used in [`tests/director.spec.ts`](https://github.com/rickcedwhat/playwright-sugar/blob/main/tests/director.spec.ts) — empty vs populated tables, admin vs viewer, toasts, and navigation.
-
-Run it locally (default URL `http://localhost:5173`):
+Start here:
 
 ```bash
+pnpm --dir lab install
 pnpm --dir lab dev
 ```
 
-In another terminal, run the docs site if you want both:
+Then, in another terminal:
 
 ```bash
 pnpm docs:dev
 ```
 
-Embedded panels below load the lab in an iframe. They only work when the lab is reachable — typically **same machine, lab on port 5173**. For a deployed docs build, set `VITE_LAB_ORIGIN` at build time (see the note at the end).
+Use the sandbox below to map UI behavior to real test commands in `tests/director.spec.ts`.
 
-## Query parameters
+## Run-this-test sandbox
 
-| Parameter | Effect |
-|-----------|--------|
-| `clear=1` | Clear persisted datasets (`localStorage`) before the app loads. |
-| `seed=<name>` | Append one dataset row (often paired with `clear=1`). |
-| `role=viewer` | Read-only user: create / rename / delete show failure toasts (matches integration tests). |
-| `view=settings` | Open the **Settings** screen instead of Datasets. |
+Pick a page context (`adminPage`/`userPage`) and operation (`create`/`update`/`delete`):
 
-`role` is read from the URL on the Datasets page, so you can change behavior without reloading storage.
+<RunTestSandbox />
 
----
+## Notes
 
-### Empty table (branching / “not found”)
-
-Use **`clear=1`** so the table starts empty — useful when explaining `.detect()` branches such as “no datasets” vs “row visible”.
-
-<LabEmbed query="clear=1" />
-
-Same URL in the address bar: `http://localhost:5173/?clear=1`
-
----
-
-### Viewer role (failure toasts / `assertCannot`)
-
-**`clear=1&role=viewer`** — empty list; try **Empty dataset** / create flows and see permission toasts, aligned with `Outcomes.failure` + soft triggers in the library.
-
-<LabEmbed query="clear=1&role=viewer" />
-
----
-
-### One seeded row (rename / row actions)
-
-**`clear=1&seed=Demo%20Dataset`** — reproducible single row for menus and rename without manual setup.
-
-<LabEmbed query="clear=1&seed=Demo%20Dataset" />
-
----
-
-### Settings route (navigation target)
-
-**`view=settings`** — neutral page for sidebar / navigation examples.
-
-<LabEmbed query="view=settings" />
-
----
+- `Run this test` copies the exact command to your clipboard; paste it in a terminal.
+- The iframe uses local lab data presets (`clear`, `seed`, `role`) so each mode is reproducible.
 
 ## Deployed docs and `VITE_LAB_ORIGIN`
 
-GitHub Pages builds for this repo currently publish **docs only**. If the iframe shows “connection refused”, start the lab locally or host the lab separately and rebuild docs with:
+GitHub Pages builds publish docs only. If iframe content is unavailable remotely, host the lab separately and build docs with:
 
 ```bash
 VITE_LAB_ORIGIN=https://your-lab-host.example pnpm docs:build
 ```
-
-You can add a `docs/.env.production` (gitignored locally) with that variable for repeatable builds.

--- a/docs/guide/sugar-lab.md
+++ b/docs/guide/sugar-lab.md
@@ -1,0 +1,74 @@
+# Sugar Lab playground
+
+The **Sugar Lab** is a small React app in the `lab/` directory. It powers the dataset flows used in [`tests/director.spec.ts`](https://github.com/rickcedwhat/playwright-sugar/blob/main/tests/director.spec.ts) — empty vs populated tables, admin vs viewer, toasts, and navigation.
+
+Run it locally (default URL `http://localhost:5173`):
+
+```bash
+pnpm --dir lab dev
+```
+
+In another terminal, run the docs site if you want both:
+
+```bash
+pnpm docs:dev
+```
+
+Embedded panels below load the lab in an iframe. They only work when the lab is reachable — typically **same machine, lab on port 5173**. For a deployed docs build, set `VITE_LAB_ORIGIN` at build time (see the note at the end).
+
+## Query parameters
+
+| Parameter | Effect |
+|-----------|--------|
+| `clear=1` | Clear persisted datasets (`localStorage`) before the app loads. |
+| `seed=<name>` | Append one dataset row (often paired with `clear=1`). |
+| `role=viewer` | Read-only user: create / rename / delete show failure toasts (matches integration tests). |
+| `view=settings` | Open the **Settings** screen instead of Datasets. |
+
+`role` is read from the URL on the Datasets page, so you can change behavior without reloading storage.
+
+---
+
+### Empty table (branching / “not found”)
+
+Use **`clear=1`** so the table starts empty — useful when explaining `.detect()` branches such as “no datasets” vs “row visible”.
+
+<LabEmbed query="clear=1" />
+
+Same URL in the address bar: `http://localhost:5173/?clear=1`
+
+---
+
+### Viewer role (failure toasts / `assertCannot`)
+
+**`clear=1&role=viewer`** — empty list; try **Empty dataset** / create flows and see permission toasts, aligned with `Outcomes.failure` + soft triggers in the library.
+
+<LabEmbed query="clear=1&role=viewer" />
+
+---
+
+### One seeded row (rename / row actions)
+
+**`clear=1&seed=Demo%20Dataset`** — reproducible single row for menus and rename without manual setup.
+
+<LabEmbed query="clear=1&seed=Demo%20Dataset" />
+
+---
+
+### Settings route (navigation target)
+
+**`view=settings`** — neutral page for sidebar / navigation examples.
+
+<LabEmbed query="view=settings" />
+
+---
+
+## Deployed docs and `VITE_LAB_ORIGIN`
+
+GitHub Pages builds for this repo currently publish **docs only**. If the iframe shows “connection refused”, start the lab locally or host the lab separately and rebuild docs with:
+
+```bash
+VITE_LAB_ORIGIN=https://your-lab-host.example pnpm docs:build
+```
+
+You can add a `docs/.env.production` (gitignored locally) with that variable for repeatable builds.

--- a/lab/README.md
+++ b/lab/README.md
@@ -18,6 +18,18 @@ Append `?role=viewer` to any URL to switch to viewer mode. In viewer mode, click
 http://localhost:5173/?role=viewer
 ```
 
+## URL presets (docs / iframes)
+
+These run **before** the first render so links and embedded demos are reproducible:
+
+| Param | Effect |
+|-------|--------|
+| `clear=1` | Remove persisted datasets (`sugar-lab-datasets`) so the list starts empty. |
+| `seed=<name>` | Append one dataset row (combine with `clear=1` for a single known row). |
+| `view=settings` | Open the Settings view instead of Datasets. |
+
+Example: `/?clear=1&seed=Demo&role=viewer`
+
 ## Scenarios
 
 ### Datasets page — Issue #10 (Playbook / Director)

--- a/lab/src/App.tsx
+++ b/lab/src/App.tsx
@@ -5,6 +5,7 @@ import DatasetsPage from './DatasetsPage';
 import DatasetDetailPage from './DatasetDetailPage';
 import SettingsPage from './SettingsPage';
 import LeaveDialog from './LeaveDialog';
+import { parseInitialRouteFromUrl } from './urlBootstrap';
 
 export type Dataset = { id: string; name: string };
 
@@ -27,7 +28,7 @@ function saveDatasets(datasets: Dataset[]) {
 
 export default function App() {
   const [datasets, setDatasets] = useState<Dataset[]>(loadDatasets);
-  const [route, setRoute] = useState<Route>({ view: 'datasets' });
+  const [route, setRoute] = useState<Route>(() => parseInitialRouteFromUrl());
   // true when the rename form is open — blocks navigation
   const [dirty, setDirty] = useState(false);
   const [pendingRoute, setPendingRoute] = useState<Route | null>(null);

--- a/lab/src/main.tsx
+++ b/lab/src/main.tsx
@@ -1,3 +1,7 @@
+import { applySugarLabUrlOverrides } from './urlBootstrap';
+
+applySugarLabUrlOverrides();
+
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';

--- a/lab/src/urlBootstrap.ts
+++ b/lab/src/urlBootstrap.ts
@@ -18,7 +18,8 @@ export function applySugarLabUrlOverrides(): void {
     const seed = p.get('seed')?.trim();
     if (seed) {
       const raw = localStorage.getItem('sugar-lab-datasets');
-      const rows: { id: string; name: string }[] = raw ? JSON.parse(raw) : [];
+      const parsed = raw ? JSON.parse(raw) : [];
+      const rows: { id: string; name: string }[] = Array.isArray(parsed) ? parsed : [];
       rows.push({ id: crypto.randomUUID(), name: seed });
       localStorage.setItem('sugar-lab-datasets', JSON.stringify(rows));
     }

--- a/lab/src/urlBootstrap.ts
+++ b/lab/src/urlBootstrap.ts
@@ -1,0 +1,40 @@
+/**
+ * Applies URL query overrides before React reads localStorage (iframe-friendly demos).
+ *
+ * Supported params:
+ * - `clear=1` — wipe persisted datasets
+ * - `seed=<name>` — append one dataset row (after optional clear)
+ * - `view=settings` — consumed by `parseInitialRouteFromUrl` in App
+ *
+ * `role=viewer` is read live from the URL in `DatasetsPage` (no bootstrap needed).
+ */
+export function applySugarLabUrlOverrides(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const p = new URLSearchParams(window.location.search);
+    if (p.get('clear') === '1') {
+      localStorage.removeItem('sugar-lab-datasets');
+    }
+    const seed = p.get('seed')?.trim();
+    if (seed) {
+      const raw = localStorage.getItem('sugar-lab-datasets');
+      const rows: { id: string; name: string }[] = raw ? JSON.parse(raw) : [];
+      rows.push({ id: crypto.randomUUID(), name: seed });
+      localStorage.setItem('sugar-lab-datasets', JSON.stringify(rows));
+    }
+  } catch {
+    // ignore malformed storage / JSON
+  }
+}
+
+type InitialRoute =
+  | { view: 'datasets' }
+  | { view: 'dataset-detail'; id: string }
+  | { view: 'settings' };
+
+export function parseInitialRouteFromUrl(): InitialRoute {
+  if (typeof window === 'undefined') return { view: 'datasets' };
+  const v = new URLSearchParams(window.location.search).get('view');
+  if (v === 'settings') return { view: 'settings' };
+  return { view: 'datasets' };
+}

--- a/src/play.ts
+++ b/src/play.ts
@@ -191,9 +191,7 @@ export class Play {
             }));
 
             const timeoutOutcome = act.outcomes.find(o => o.isTimeoutOutcome);
-            const timeout =
-              act.timeout ??
-              (timeoutOutcome?.after !== undefined ? timeoutOutcome.after : undefined);
+            const timeout = act.timeout ?? timeoutOutcome?.after;
 
             const attemptParams: Parameters<typeof attemptAction>[0] = {
               action: () => act.trigger(page, ctx),

--- a/tests/director.spec.ts
+++ b/tests/director.spec.ts
@@ -9,6 +9,7 @@ import { Director, Playbook, Play, Outcomes, SyncStrategy } from '../src/index.j
 type ExistsParams = { name: string; withReload?: boolean };
 type CreateParams = { name: string };
 type UpdateParams = { name: string; newName: string };
+type DeleteParams = { name: string };
 
 const datasetPb = new Playbook('DatasetPlaybook', {
 
@@ -71,6 +72,21 @@ const datasetPb = new Playbook('DatasetPlaybook', {
         await page.keyboard.press('Escape');
       }
     }),
+
+  delete: ({ name }: DeleteParams) => new Play()
+    .nav(async page => { await page.getByRole('button', { name: 'Datasets' }).click(); })
+    .prep(async page => {
+      await page.locator(`tr:has-text("${name}")`).getByRole('button', { name: 'Row actions' }).click();
+      await page.getByRole('menuitem', { name: 'Delete' }).click();
+    })
+    .attempt(
+      async () => {},
+      [
+        Outcomes.success(page => page.getByText('Deleted dataset')),
+        Outcomes.failure(page => page.locator('li[data-sonner-toast]').filter({ hasText: /Failed to/i })),
+        Outcomes.timeout(5000),
+      ],
+    ),
 });
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -159,6 +175,32 @@ test('assertCannot: viewer cannot rename dataset, cleanup presses Escape', async
   // Dataset name is unchanged
   await page.getByRole('button', { name: 'Datasets' }).click();
   await expect(page.locator('tr:has-text("Protected Dataset")')).toBeVisible();
+});
+
+test('assertCan: admin deletes dataset', async ({ page }) => {
+  await seedDataset(page, 'Delete Me');
+
+  const director = new Director();
+  const pb = datasetPb.withCtx({ page });
+
+  await director.assertCan(pb, 'delete', { name: 'Delete Me' });
+
+  await page.getByRole('button', { name: 'Datasets' }).click();
+  await expect(page.locator('tr:has-text("Delete Me")')).not.toBeVisible();
+});
+
+test('assertCannot: viewer cannot delete dataset', async ({ page }) => {
+  await seedDataset(page, 'Protected Delete');
+  await page.goto('/?role=viewer');
+
+  const director = new Director();
+  const pb = datasetPb.withCtx({ page });
+
+  const result = await director.assertCannot(pb, 'delete', { name: 'Protected Delete' });
+  expect(result.isSuccess).toBe(false);
+
+  await page.getByRole('button', { name: 'Datasets' }).click();
+  await expect(page.locator('tr:has-text("Protected Delete")')).toBeVisible();
 });
 
 // ── ensureExists ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Replace the Sugar Lab guide's multiple static embeds with a single interactive sandbox.
- Add toggles for `adminPage`/`userPage` and `create`/`update`/`delete` that update one code snippet and run command.
- Add a `Run this test` button that copies the exact `pnpm test --grep` command for the selected scenario.

## Validation
- pnpm exec tsc
- pnpm exec vitest run
- pnpm docs:build


Made with [Cursor](https://cursor.com)