### PR TITLE
feat(play)!: third-arg outcome and Play.run lastOutcome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed (breaking)
 
 - **`Play` / `PlayCtx`** — detect and attempt resolutions are no longer stored on `ctx.state` / `ctx.result` or on `ctx`. Use the **third callback argument** `(page, ctx, outcome)` on every act (`outcome` is `undefined` until after a `.detect()` or `.attempt()`). Shape: `{ name, isSuccess, locator?, payload? }` where `payload` is the winning branch’s `onOutcome` return. **`Play.run()`** returns `{ ctx, lastOutcome? }` so callers (e.g. `Director`) can read the final resolution without mutating context.
-- **`attemptAction` / `detectPageState`** — return value uses **`payload`** (not `data`) and may include **`locator`** when a locator-based outcome wins.
+- **`attemptAction` / `detectPageState`** — return value uses **`payload`** (not `data`) and may include **`locator`** when a locator-based outcome wins. Soft timeout and action-error fallbacks **do not invoke `onOutcome`** (no winning locator; previously `onOutcome` could run with a null locator).
 - **`Director` / `PlayResult`** — `PlayResult.data` is replaced by **`PlayResult.payload`**, aligned with `PlayOutcome.payload`.
 - **`attemptAction`** — signature is now positional: `attemptAction(action, outcomes, opts?)`. The previous single-object parameter is removed. Use `async () => {}` as the action when you only need to poll outcomes (or use **`detectPageState`**).
 - **`Play.attempt`** — optional third/fourth argument is now `AttemptActionOptions` (e.g. `{ timeout: 5000 }`) instead of a bare `timeout` number, aligned with `attemptAction`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (breaking)
 
+- **`Play` / `PlayCtx`** — detect and attempt resolutions are no longer stored on `ctx.state` / `ctx.result` or on `ctx`. Use the **third callback argument** `(page, ctx, outcome)` on every act (`outcome` is `undefined` until after a `.detect()` or `.attempt()`). Shape: `{ name, isSuccess, locator?, payload? }` where `payload` is the winning branch’s `onOutcome` return. **`Play.run()`** returns `{ ctx, lastOutcome? }` so callers (e.g. `Director`) can read the final resolution without mutating context.
+- **`attemptAction` / `detectPageState`** — return value uses **`payload`** (not `data`) and may include **`locator`** when a locator-based outcome wins.
+- **`Director` / `PlayResult`** — `PlayResult.data` is replaced by **`PlayResult.payload`**, aligned with `PlayOutcome.payload`.
 - **`attemptAction`** — signature is now positional: `attemptAction(action, outcomes, opts?)`. The previous single-object parameter is removed. Use `async () => {}` as the action when you only need to poll outcomes (or use **`detectPageState`**).
 - **`Play.attempt`** — optional third/fourth argument is now `AttemptActionOptions` (e.g. `{ timeout: 5000 }`) instead of a bare `timeout` number, aligned with `attemptAction`.
 

--- a/docs/api/attempt-action.md
+++ b/docs/api/attempt-action.md
@@ -5,14 +5,13 @@ Runs a **required** action, then waits for one of several named outcomes to appe
 ## Signature
 
 ```ts
-import type { Locator } from '@playwright/test';
-import type { AttemptActionOptions } from '@rickcedwhat/playwright-sugar';
+import type { AttemptActionOptions, AttemptResolution } from '@rickcedwhat/playwright-sugar';
 
 attemptAction(
   action: () => Promise<void>,
   outcomes: Outcome[],
   opts?: AttemptActionOptions
-): Promise<{ isSuccess: boolean; outcome: string; payload?: unknown; locator?: Locator }>
+): Promise<AttemptResolution>
 ```
 
 `AttemptActionOptions` is an object so you can add future fields (poll tuning, debug flags) without changing the positional shape.
@@ -21,14 +20,16 @@ attemptAction(
 |-------|------|-------------|
 | `timeout` | `number` | Polling budget in ms. Default **30000**. Does not replace soft timeout outcomes — see below. |
 
-## Return value
+## Return value (`AttemptResolution`)
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `isSuccess` | `boolean` | `true` if the winning outcome was created with `Outcomes.success`. |
 | `outcome` | `string` | The name of the winning outcome. |
-| `payload` | `unknown` | Optional value returned by the outcome's `onOutcome` callback. |
-| `locator` | `Locator` | Present when a locator-based outcome won (not on all timeout paths). |
+| `payload` | `unknown` | Present only when the winning branch’s `onOutcome` returned a defined value. |
+| `locator?` | `Locator` | Present only when a **locator-based** outcome won (omitted on soft timeout / action-error paths). |
+
+`onOutcome` runs only when an outcome becomes the visible winner with a real `Locator`. **Soft timeout** and **action-error** resolutions do not call `onOutcome` — there is no winning element.
 
 ## Examples
 

--- a/docs/api/attempt-action.md
+++ b/docs/api/attempt-action.md
@@ -5,13 +5,14 @@ Runs a **required** action, then waits for one of several named outcomes to appe
 ## Signature
 
 ```ts
+import type { Locator } from '@playwright/test';
 import type { AttemptActionOptions } from '@rickcedwhat/playwright-sugar';
 
 attemptAction(
   action: () => Promise<void>,
   outcomes: Outcome[],
   opts?: AttemptActionOptions
-): Promise<{ isSuccess: boolean; outcome: string; data?: unknown }>
+): Promise<{ isSuccess: boolean; outcome: string; payload?: unknown; locator?: Locator }>
 ```
 
 `AttemptActionOptions` is an object so you can add future fields (poll tuning, debug flags) without changing the positional shape.
@@ -26,7 +27,8 @@ attemptAction(
 |-------|------|-------------|
 | `isSuccess` | `boolean` | `true` if the winning outcome was created with `Outcomes.success`. |
 | `outcome` | `string` | The name of the winning outcome. |
-| `data` | `unknown` | Optional data returned by the outcome's `onOutcome` callback. |
+| `payload` | `unknown` | Optional value returned by the outcome's `onOutcome` callback. |
+| `locator` | `Locator` | Present when a locator-based outcome won (not on all timeout paths). |
 
 ## Examples
 

--- a/docs/api/director.md
+++ b/docs/api/director.md
@@ -70,6 +70,6 @@ await director.ensureExists(adminPb, { name: 'Shared Dataset' }, {
 type PlayResult = {
   isSuccess: boolean;
   outcome: string;
-  data?: unknown;
+  payload?: unknown;
 }
 ```

--- a/docs/api/play.md
+++ b/docs/api/play.md
@@ -36,7 +36,7 @@ new Play().reload({ waitUntil: 'domcontentloaded' }, { skip: !withReload })
 
 ### .detect(fn, opts?)
 
-Waits for one of several locators to appear and records the winner in `ctx.state`. Used for branching (e.g. determine whether a table is empty or populated).
+Waits for one of several locators to appear and passes the winner as the **third argument** to every following act. Used for branching (e.g. determine whether a table is empty or populated). The same resolution is also exposed on **`Play.run()`’s return value** as `lastOutcome` (see below).
 
 ```ts
 new Play().detect(page => [
@@ -45,7 +45,7 @@ new Play().detect(page => [
 ], { timeout: 8000 })
 ```
 
-`ctx.state` is set to `{ name, isSuccess, data }` after detect runs.
+After detect runs, the next act’s third argument `outcome` is `{ name, isSuccess, locator?, payload? }`. `payload` comes from the winning branch’s `onOutcome`, if any. Nothing is written onto `ctx` for this — use `outcome` or the `lastOutcome` field from `.run()`’s result.
 
 ### .attempt(action, outcomes, opts?)  /  .attempt(name, action, outcomes, opts?)
 
@@ -55,8 +55,8 @@ Performs an action and waits for an outcome. The optional third/fourth argument 
 
 ```ts
 new Play().attempt(
-  async (page, ctx) => {
-    const btn = ctx['state']?.name === 'empty' ? 'Empty item' : 'Item';
+  async (page, _ctx, outcome) => {
+    const btn = outcome?.name === 'empty' ? 'Empty item' : 'Item';
     await page.getByRole('button', { name: btn }).click();
     await page.getByPlaceholder('Name').fill('My Item');
     await page.getByRole('button', { name: 'Create' }).click();
@@ -95,7 +95,7 @@ new Play().attempt(
 )
 ```
 
-`ctx.result` is set to `{ isSuccess, outcome, data }` after the attempt.
+After the attempt, the next act’s third argument `outcome` is the attempt resolution (`name` is the winning outcome’s name, `payload` from `onOutcome` if present). It is `undefined` before the first `.detect()` or `.attempt()`.
 
 #### Timeout semantics
 
@@ -103,7 +103,7 @@ Timeouts are resolved in this order:
 
 1. **`opts.timeout`**: passed through to `attemptAction` as the polling budget. If no locator outcome wins before this limit **and** there is **no** `Outcomes.timeout()` outcome in the list, `attemptAction` throws (hard timeout).
 
-2. **`Outcomes.timeout(after)`** (soft timeout outcome): supplies an `after` value used as the polling budget **when** `opts.timeout` is not set. If the timer expires without another locator winning, the winner is the timeout **outcome** — resolution completes normally and `ctx.result` reflects that outcome (typically `isSuccess: false`), rather than throwing.
+2. **`Outcomes.timeout(after)`** (soft timeout outcome): supplies an `after` value used as the polling budget **when** `opts.timeout` is not set. If the timer expires without another locator winning, the winner is the timeout **outcome** — resolution completes normally and the next act’s `outcome` argument (and `run()`’s `lastOutcome`) reflect that result (typically `isSuccess: false`), rather than throwing.
 
 3. **Default** (30 seconds): used when neither `opts.timeout` nor a timeout outcome with an `after` value applies.
 
@@ -114,8 +114,8 @@ Whether expiry throws or returns a named outcome depends on your outcome list: i
 Runs after a successful attempt — typically reverts state so the test is idempotent. Skipped if the attempt was never reached or if a prior step threw.
 
 ```ts
-new Play().cleanup(async (page, ctx) => {
-  if ((ctx.result as any)?.isSuccess) {
+new Play().cleanup(async (page, _ctx, outcome) => {
+  if (outcome?.isSuccess) {
     // revert the change
   } else {
     await page.keyboard.press('Escape');
@@ -128,18 +128,33 @@ new Play().cleanup(async (page, ctx) => {
 ### .run(label, ctx)
 
 ```ts
-play.run(label: string, ctx: PlayCtx): Promise<PlayCtx>
+play.run(label: string, ctx: PlayCtx): Promise<PlayRunResult>
+
+type PlayRunResult = {
+  ctx: PlayCtx;
+  /** Final `.detect()` / `.attempt()` resolution in this run, if any. */
+  lastOutcome?: PlayOutcome;
+}
 ```
 
-Executes all steps in order. Calls `page.bringToFront()` automatically. Logs each step with ✅ / ❌ / ⏭ and timing. Normally called by `Director` rather than directly.
+Executes all steps in order. Calls `page.bringToFront()` automatically. Logs each step with ✅ / ❌ / ⏭ and timing. Normally called by `Director` rather than directly. **`ctx` is not mutated with detect/attempt results** — read `lastOutcome` from the return value, or use the **third callback argument** inside each step.
 
 ## Step context (PlayCtx)
 
 ```ts
+import type { Locator } from '@playwright/test';
+
+type PlayOutcome = {
+  name: string;
+  isSuccess: boolean;
+  locator?: Locator;
+  payload?: unknown;
+};
+
 type PlayCtx = {
   page: Page;
-  state: { name: string; isSuccess: boolean; data?: unknown } | null;
-  result: { isSuccess: boolean; outcome: string; data?: unknown } | null;
   [key: string]: unknown; // extra keys from Playbook.withCtx()
 }
 ```
+
+Every act callback has the shape `(page, ctx, outcome)` where `outcome` is `undefined` until a prior step was `.detect()` or `.attempt()`.

--- a/docs/api/play.md
+++ b/docs/api/play.md
@@ -111,7 +111,7 @@ Whether expiry throws or returns a named outcome depends on your outcome list: i
 
 ### .cleanup(fn, opts?)
 
-Runs after a successful attempt — typically reverts state so the test is idempotent. Skipped if the attempt was never reached or if a prior step threw.
+Runs after an **attempt** step has finished (success or failure), unless a prior step threw — typically used to revert state or dismiss UI so the test stays idempotent. Skipped if the attempt was never reached or if a prior step threw.
 
 ```ts
 new Play().cleanup(async (page, _ctx, outcome) => {

--- a/docs/api/playbook.md
+++ b/docs/api/playbook.md
@@ -52,4 +52,4 @@ Returns the bound page. Throws if `.withCtx({ page })` has not been called.
 
 ## .buildCtx()
 
-Returns an initial `PlayCtx` from the bound context with `state` and `result` initialised to `null`. Called internally by `Director`.
+Returns an initial `PlayCtx` from the bound context. Called internally by `Director`.

--- a/src/attemptAction.ts
+++ b/src/attemptAction.ts
@@ -131,23 +131,17 @@ ${errorMsg}
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
 
-  // Timeout Handling
-  const timeoutOutcome = actionError 
-    ? (normalizedOutcomes.find((o) => o.isActionErrorOutcome) || normalizedOutcomes.find((o) => o.isTimeoutOutcome))
+  // Timeout Handling — no visible winner; do not run onOutcome (no winning locator).
+  const timeoutOutcome = actionError
+    ? normalizedOutcomes.find((o) => o.isActionErrorOutcome) ||
+      normalizedOutcomes.find((o) => o.isTimeoutOutcome)
     : normalizedOutcomes.find((o) => o.isTimeoutOutcome);
 
   if (timeoutOutcome) {
-    let payload: unknown | undefined = undefined;
-    if (timeoutOutcome.onOutcome) {
-      payload = await timeoutOutcome.onOutcome(null as any);
-    }
-
-    const resolution: AttemptResolution = {
+    return {
       isSuccess: timeoutOutcome.isSuccess,
       outcome: timeoutOutcome.name,
     };
-    if (payload !== undefined) resolution.payload = payload;
-    return resolution;
   }
 
   const debugList = normalizedOutcomes

--- a/src/attemptAction.ts
+++ b/src/attemptAction.ts
@@ -9,6 +9,14 @@ export type Outcome = {
   onOutcome?: (winner: Locator) => Promise<unknown>;
 };
 
+/** Resolution from {@link attemptAction} / {@link detectPageState} — maps to {@link PlayOutcome}. */
+export type AttemptResolution = {
+  isSuccess: boolean;
+  outcome: string;
+  payload?: unknown;
+  locator?: Locator;
+};
+
 /** Options for `attemptAction` / `Play.attempt` — extend with future flags without breaking the positional API. */
 export type AttemptActionOptions = {
   timeout?: number;
@@ -18,7 +26,7 @@ export async function attemptAction(
   action: () => Promise<void>,
   outcomes: Outcome[],
   opts?: AttemptActionOptions
-): Promise<{ isSuccess: boolean; outcome: string; data?: unknown }> {
+): Promise<AttemptResolution> {
   const normalizedOutcomes = outcomes;
   const timeout = opts?.timeout ?? 30000;
 
@@ -106,15 +114,17 @@ ${errorMsg}
         const winner = realWinners[0];
         if (!winner) throw new Error('Winner vanished during processing');
         
-        let data = undefined;
+        let payload: unknown | undefined = undefined;
         if (winner.outcome.onOutcome && winner.locator) {
-          data = await winner.outcome.onOutcome(winner.locator);
+          payload = await winner.outcome.onOutcome(winner.locator);
         }
-        return {
+        const resolution: AttemptResolution = {
           isSuccess: winner.outcome.isSuccess,
           outcome: winner.outcome.name,
-          data,
         };
+        if (payload !== undefined) resolution.payload = payload;
+        if (winner.locator != null) resolution.locator = winner.locator;
+        return resolution;
       }
     }
 
@@ -127,15 +137,17 @@ ${errorMsg}
     : normalizedOutcomes.find((o) => o.isTimeoutOutcome);
 
   if (timeoutOutcome) {
-    const data = timeoutOutcome.onOutcome
-      ? await timeoutOutcome.onOutcome(null as any)
-      : undefined;
-      
-    return {
+    let payload: unknown | undefined = undefined;
+    if (timeoutOutcome.onOutcome) {
+      payload = await timeoutOutcome.onOutcome(null as any);
+    }
+
+    const resolution: AttemptResolution = {
       isSuccess: timeoutOutcome.isSuccess,
       outcome: timeoutOutcome.name,
-      data,
     };
+    if (payload !== undefined) resolution.payload = payload;
+    return resolution;
   }
 
   const debugList = normalizedOutcomes

--- a/src/director.ts
+++ b/src/director.ts
@@ -10,7 +10,8 @@ export type EnsureExistsOptions = {
 export type PlayResult = {
   isSuccess: boolean;
   outcome: string;
-  data?: unknown;
+  /** From the winning detect/attempt branch’s `onOutcome`, if any. */
+  payload?: unknown;
 };
 
 const SYNC_RETRY_TIMEOUT = 30_000;
@@ -19,7 +20,7 @@ const SYNC_RETRY_INTERVAL = 500;
 export class Director {
   /**
    * Runs a play and asserts that it resulted in a **success** outcome.
-   * Throws if the play produced no attempt result or a failure outcome.
+   * Throws if the play produced no detect/attempt outcome or a failure outcome.
    */
   async assertCan(
     playbook: Playbook,
@@ -51,6 +52,14 @@ export class Director {
       );
     }
     return result;
+  }
+
+  /**
+   * Runs a play and returns the outcome without asserting.
+   * Use with `assertCan` / `assertCannot` when you need to aggregate results (e.g. permission matrices).
+   */
+  async run(playbook: Playbook, playName: string, params: unknown): Promise<PlayResult> {
+    return this._runPlay(playbook, playName, params);
   }
 
   /**
@@ -93,16 +102,15 @@ export class Director {
     const ctx = playbook.buildCtx();
     const label = `${playbook.name} > ${playName}`;
 
-    const finalCtx = await play.run(label, ctx);
+    const { lastOutcome } = await play.run(label, ctx);
 
-    if (finalCtx['result']) {
-      return finalCtx['result'] as PlayResult;
-    }
-
-    // exists-style plays use .detect() with no .attempt() — promote state to result
-    if (finalCtx['state']) {
-      const s = finalCtx['state'] as { name: string; isSuccess: boolean; data?: unknown };
-      return { isSuccess: s.isSuccess, outcome: s.name, data: s.data };
+    if (lastOutcome) {
+      const r: PlayResult = {
+        isSuccess: lastOutcome.isSuccess,
+        outcome: lastOutcome.name,
+      };
+      if (lastOutcome.payload !== undefined) r.payload = lastOutcome.payload;
+      return r;
     }
 
     return { isSuccess: false, outcome: 'no-attempt' };

--- a/src/play.test.ts
+++ b/src/play.test.ts
@@ -41,13 +41,13 @@ const mockLocator = {} as any;
 describe('Play.run() always calls bringToFront', () => {
   it('calls page.bringToFront() before the first act', async () => {
     const page = makePage();
-    await new Play().act('nav', async () => {}).run('label', { page, state: null, result: null });
+    await new Play().act('nav', async () => {}).run('label', { page });
     expect(page.bringToFront).toHaveBeenCalledOnce();
   });
 
   it('calls bringToFront even when all acts are skipped', async () => {
     const page = makePage();
-    await new Play().act('nav', async () => {}, { skip: true }).run('label', { page, state: null, result: null });
+    await new Play().act('nav', async () => {}, { skip: true }).run('label', { page });
     expect(page.bringToFront).toHaveBeenCalledOnce();
   });
 });
@@ -64,7 +64,7 @@ describe('Play chain order', () => {
       .act('second', async () => { order.push(2); })
       .act('third', async () => { order.push(3); });
 
-    await play.run('label', { page, state: null, result: null });
+    await play.run('label', { page });
 
     expect(order).toEqual([1, 2, 3]);
   });
@@ -73,14 +73,14 @@ describe('Play chain order', () => {
     const names: string[] = [];
     const page = makePage();
 
-    mockAttemptAction.mockResolvedValueOnce({ isSuccess: true, outcome: 'ok', data: undefined });
+    mockAttemptAction.mockResolvedValueOnce({ isSuccess: true, outcome: 'ok', payload: undefined });
 
     const play = new Play()
       .nav(async () => { names.push('nav'); })
       .prep(async () => { names.push('prep'); })
       .attempt(async () => {}, [Outcomes.success(mockLocator)]);
 
-    await play.run('label', { page, state: null, result: null });
+    await play.run('label', { page });
 
     expect(names).toEqual(['nav', 'prep']);
   });
@@ -95,7 +95,7 @@ describe('ActOptions.skip', () => {
 
     const play = new Play().act('skipped', fn, { skip: true });
 
-    await play.run('label', { page, state: null, result: null });
+    await play.run('label', { page });
 
     expect(fn).not.toHaveBeenCalled();
   });
@@ -108,7 +108,7 @@ describe('ActOptions.skip', () => {
       .act('skipped', vi.fn(), { skip: true })
       .act('runs', fn);
 
-    await play.run('label', { page, state: null, result: null });
+    await play.run('label', { page });
 
     expect(fn).toHaveBeenCalledOnce();
   });
@@ -118,7 +118,7 @@ describe('ActOptions.skip', () => {
 
     const play = new Play().reload({ waitUntil: 'domcontentloaded' }, { skip: true });
 
-    await play.run('label', { page, state: null, result: null });
+    await play.run('label', { page });
 
     expect(page.reload).not.toHaveBeenCalled();
   });
@@ -131,7 +131,7 @@ describe('.reload()', () => {
     const page = makePage();
     const play = new Play().reload({ waitUntil: 'domcontentloaded', timeout: 5000 });
 
-    await play.run('label', { page, state: null, result: null });
+    await play.run('label', { page });
 
     expect(page.reload).toHaveBeenCalledWith({ waitUntil: 'domcontentloaded', timeout: 5000 });
   });
@@ -140,42 +140,76 @@ describe('.reload()', () => {
     const page = makePage();
     const play = new Play().reload();
 
-    await play.run('label', { page, state: null, result: null });
+    await play.run('label', { page });
 
     expect(page.reload).toHaveBeenCalledWith(undefined);
   });
 });
 
-// ── .detect() → ctx.state ────────────────────────────────────────────────────
+// ── .detect() — run().lastOutcome + third arg ─────────────────────────────────
 
-describe('.detect() ctx.state', () => {
+describe('.detect() run result and third arg', () => {
   beforeEach(() => {
-    mockDetectPageState.mockResolvedValue({ isSuccess: true, outcome: 'found', data: undefined });
+    mockDetectPageState.mockResolvedValue({ isSuccess: true, outcome: 'found', payload: undefined });
   });
 
-  it('sets ctx.state with the name and isSuccess from the winning outcome', async () => {
+  it('play.run returns lastOutcome from detect', async () => {
     const page = makePage();
 
     const play = new Play().detect(() => [
       { name: 'found', isSuccess: true, locator: mockLocator },
     ]);
 
-    const ctx = await play.run('label', { page, state: null, result: null });
+    const { lastOutcome } = await play.run('label', { page });
 
-    expect(ctx['state']).toEqual({ name: 'found', isSuccess: true, data: undefined });
+    expect(lastOutcome).toMatchObject({ name: 'found', isSuccess: true });
   });
 
-  it('ctx.state is available in acts that follow detect', async () => {
+  it('forwards optional onOutcome on detect candidates to detectPageState outcomes', async () => {
     const page = makePage();
-    let seenState: unknown = undefined;
+    mockDetectPageState.mockResolvedValue({ isSuccess: true, outcome: 'a', payload: { picked: true } });
 
+    const onOutcome = vi.fn().mockResolvedValue({ picked: true });
+    const play = new Play().detect(() => [
+      { name: 'a', isSuccess: true, locator: mockLocator, onOutcome },
+    ]);
+
+    await play.run('label', { page });
+
+    expect(mockDetectPageState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcomes: [
+          expect.objectContaining({
+            name: 'a',
+            isSuccess: true,
+            locator: mockLocator,
+            onOutcome,
+          }),
+        ],
+      })
+    );
+  });
+
+  it('passes undefined as third arg to acts before any detect/attempt', async () => {
+    const page = makePage();
+    let arg: unknown = 'unset';
+    const play = new Play().act('first', async (_p, _c, outcome) => { arg = outcome; });
+
+    await play.run('label', { page });
+
+    expect(arg).toBeUndefined();
+  });
+
+  it('passes detect outcome as third arg to the following act', async () => {
+    const page = makePage();
+    let arg: unknown;
     const play = new Play()
       .detect(() => [{ name: 'found', isSuccess: true, locator: mockLocator }])
-      .act('read-state', async (_p, ctx) => { seenState = ctx['state']; });
+      .act('after', async (_p, _c, outcome) => { arg = outcome; });
 
-    await play.run('label', { page, state: null, result: null });
+    await play.run('label', { page });
 
-    expect(seenState).toMatchObject({ name: 'found', isSuccess: true });
+    expect(arg).toMatchObject({ name: 'found', isSuccess: true });
   });
 });
 
@@ -190,7 +224,7 @@ describe('.attempt() and .cleanup()', () => {
       .act('only-act', async () => {})
       .cleanup(cleanupFn);
 
-    await play.run('label', { page, state: null, result: null });
+    await play.run('label', { page });
 
     expect(cleanupFn).not.toHaveBeenCalled();
   });
@@ -198,13 +232,13 @@ describe('.attempt() and .cleanup()', () => {
   it('cleanup runs when attempt was reached (success outcome)', async () => {
     const cleanupFn = vi.fn().mockResolvedValue(undefined);
     const page = makePage();
-    mockAttemptAction.mockResolvedValueOnce({ isSuccess: true, outcome: 'ok', data: undefined });
+    mockAttemptAction.mockResolvedValueOnce({ isSuccess: true, outcome: 'ok', payload: undefined });
 
     const play = new Play()
       .attempt(async () => {}, [Outcomes.success(mockLocator)])
       .cleanup(cleanupFn);
 
-    await play.run('label', { page, state: null, result: null });
+    await play.run('label', { page });
 
     expect(cleanupFn).toHaveBeenCalledOnce();
   });
@@ -212,41 +246,68 @@ describe('.attempt() and .cleanup()', () => {
   it('cleanup runs when attempt was reached (failure outcome)', async () => {
     const cleanupFn = vi.fn().mockResolvedValue(undefined);
     const page = makePage();
-    mockAttemptAction.mockResolvedValueOnce({ isSuccess: false, outcome: 'fail', data: undefined });
+    mockAttemptAction.mockResolvedValueOnce({ isSuccess: false, outcome: 'fail', payload: undefined });
 
     const play = new Play()
       .attempt(async () => {}, [Outcomes.failure(mockLocator)])
       .cleanup(cleanupFn);
 
-    await play.run('label', { page, state: null, result: null });
+    await play.run('label', { page });
 
     expect(cleanupFn).toHaveBeenCalledOnce();
   });
 
-  it('cleanup receives ctx.result from the attempt', async () => {
+  it('cleanup receives attempt outcome as third argument', async () => {
     const page = makePage();
-    let seenResult: unknown;
-    mockAttemptAction.mockResolvedValueOnce({ isSuccess: false, outcome: 'blocked', data: undefined });
+    let seenArg: unknown;
+    mockAttemptAction.mockResolvedValueOnce({ isSuccess: false, outcome: 'blocked', payload: undefined });
 
     const play = new Play()
       .attempt(async () => {}, [Outcomes.failure(mockLocator)])
-      .cleanup(async (_p, ctx) => { seenResult = ctx['result']; });
+      .cleanup(async (_p, _c, outcome) => {
+        seenArg = outcome;
+      });
 
-    await play.run('label', { page, state: null, result: null });
+    await play.run('label', { page });
 
-    expect(seenResult).toMatchObject({ isSuccess: false, outcome: 'blocked' });
+    expect(seenArg).toMatchObject({ isSuccess: false, name: 'blocked' });
   });
 
-  it('sets ctx.result with the attempt outcome', async () => {
+  it('attempt trigger receives prior detect outcome as third argument', async () => {
     const page = makePage();
-    mockAttemptAction.mockResolvedValueOnce({ isSuccess: true, outcome: 'created', data: 42 });
+    mockDetectPageState.mockResolvedValueOnce({
+      isSuccess: true,
+      outcome: 'empty',
+      payload: 7,
+      locator: mockLocator,
+    });
+    let received: unknown;
+    mockAttemptAction.mockImplementationOnce(async (trigger: () => Promise<void>) => {
+      await trigger();
+      return { isSuccess: true, outcome: 'done', payload: undefined };
+    });
+
+    const play = new Play()
+      .detect(() => [{ name: 'empty', isSuccess: true, locator: mockLocator }])
+      .attempt('step', async (_p, _c, o) => {
+        received = o;
+      }, [Outcomes.success(mockLocator)]);
+
+    await play.run('label', { page });
+
+    expect(received).toMatchObject({ name: 'empty', isSuccess: true, payload: 7 });
+  });
+
+  it('play.run returns lastOutcome after attempt from attemptAction resolution', async () => {
+    const page = makePage();
+    mockAttemptAction.mockResolvedValueOnce({ isSuccess: true, outcome: 'created', payload: 42 });
 
     const play = new Play()
       .attempt(async () => {}, [Outcomes.success(mockLocator)]);
 
-    const ctx = await play.run('label', { page, state: null, result: null });
+    const { lastOutcome } = await play.run('label', { page });
 
-    expect(ctx['result']).toEqual({ isSuccess: true, outcome: 'created', data: 42 });
+    expect(lastOutcome).toMatchObject({ name: 'created', isSuccess: true, payload: 42 });
   });
 });
 
@@ -259,7 +320,7 @@ describe('error labels', () => {
 
     const play = new Play().act('prep', async () => { throw cause; });
 
-    await expect(play.run('MyPb > update', { page, state: null, result: null }))
+    await expect(play.run('MyPb > update', { page }))
       .rejects.toThrow('[MyPb > update > prep] row not found');
   });
 
@@ -271,7 +332,7 @@ describe('error labels', () => {
 
     let thrown: Error | undefined;
     try {
-      await play.run('label', { page, state: null, result: null });
+      await play.run('label', { page });
     } catch (e) {
       thrown = e as Error;
     }
@@ -285,7 +346,7 @@ describe('error labels', () => {
 
     const play = new Play().attempt('submit', async () => {}, [Outcomes.success(mockLocator)]);
 
-    await expect(play.run('Pb > play', { page, state: null, result: null }))
+    await expect(play.run('Pb > play', { page }))
       .rejects.toThrow('[Pb > play > submit]');
   });
 });
@@ -301,14 +362,14 @@ describe('.attempt() locator resolution', () => {
     let capturedOutcomes: unknown;
     mockAttemptAction.mockImplementationOnce(async (_a, outcomes) => {
       capturedOutcomes = outcomes;
-      return { isSuccess: true, outcome: 'success', data: undefined };
+      return { isSuccess: true, outcome: 'success', payload: undefined };
     });
 
     const play = new Play().attempt(async () => {}, [
       Outcomes.success(p => p.getByText('This dataset is empty')),
     ]);
 
-    await play.run('label', { page, state: null, result: null });
+    await play.run('label', { page });
 
     const outcome = (capturedOutcomes as any[])[0];
     expect(outcome.locator).toBe(resolvedLocator);
@@ -320,14 +381,14 @@ describe('.attempt() locator resolution', () => {
     (page.getByText as unknown as MockInstance).mockReturnValue({});
     let capturedCtx: unknown;
     mockAttemptAction.mockImplementationOnce(async () =>
-      ({ isSuccess: true, outcome: 'success', data: undefined })
+      ({ isSuccess: true, outcome: 'success', payload: undefined })
     );
 
     const play = new Play().attempt(async () => {}, [
       Outcomes.success((_p, ctx) => { capturedCtx = ctx; return _p.getByText('test'); }),
     ]);
 
-    await play.run('label', { page, state: null, result: null });
+    await play.run('label', { page });
 
     expect(capturedCtx).toBeDefined();
     expect(typeof capturedCtx).toBe('object');
@@ -338,7 +399,7 @@ describe('.attempt() locator resolution', () => {
     let capturedTimeout: unknown;
     mockAttemptAction.mockImplementationOnce(async (_a, _o, opts) => {
       capturedTimeout = opts?.timeout;
-      return { isSuccess: true, outcome: 'ok', data: undefined };
+      return { isSuccess: true, outcome: 'ok', payload: undefined };
     });
 
     const play = new Play().attempt(async () => {}, [
@@ -346,7 +407,7 @@ describe('.attempt() locator resolution', () => {
       Outcomes.timeout(8000),
     ]);
 
-    await play.run('label', { page, state: null, result: null });
+    await play.run('label', { page });
 
     expect(capturedTimeout).toBe(8000);
   });
@@ -356,7 +417,7 @@ describe('.attempt() locator resolution', () => {
     let capturedTimeout: unknown;
     mockAttemptAction.mockImplementationOnce(async (_a, _o, opts) => {
       capturedTimeout = opts?.timeout;
-      return { isSuccess: true, outcome: 'ok', data: undefined };
+      return { isSuccess: true, outcome: 'ok', payload: undefined };
     });
 
     const play = new Play().attempt(
@@ -365,7 +426,7 @@ describe('.attempt() locator resolution', () => {
       { timeout: 12_000 }
     );
 
-    await play.run('label', { page, state: null, result: null });
+    await play.run('label', { page });
 
     expect(capturedTimeout).toBe(12_000);
   });
@@ -375,7 +436,7 @@ describe('.attempt() locator resolution', () => {
     let capturedTimeout: unknown;
     mockAttemptAction.mockImplementationOnce(async (_a, _o, opts) => {
       capturedTimeout = opts?.timeout;
-      return { isSuccess: true, outcome: 'ok', data: undefined };
+      return { isSuccess: true, outcome: 'ok', payload: undefined };
     });
 
     const play = new Play().attempt(
@@ -385,7 +446,7 @@ describe('.attempt() locator resolution', () => {
       { timeout: 7000 }
     );
 
-    await play.run('label', { page, state: null, result: null });
+    await play.run('label', { page });
 
     expect(capturedTimeout).toBe(7000);
   });
@@ -509,19 +570,19 @@ describe('Play logging', () => {
 
   it('logs ▶ Play: label at the start', async () => {
     const page = makePage();
-    await new Play().run('MyPb > exists', { page, state: null, result: null });
+    await new Play().run('MyPb > exists', { page });
     expect(logSpy).toHaveBeenCalledWith('▶ Play: MyPb > exists');
   });
 
   it('logs ✅ for a successful act', async () => {
     const page = makePage();
-    await new Play().act('nav', async () => {}).run('label', { page, state: null, result: null });
+    await new Play().act('nav', async () => {}).run('label', { page });
     expect(logSpy).toHaveBeenCalledWith(expect.stringMatching(/✅ nav\s+\(\d+ms\)/));
   });
 
   it('logs ⏭ for a skipped act', async () => {
     const page = makePage();
-    await new Play().act('prep', async () => {}, { skip: true }).run('label', { page, state: null, result: null });
+    await new Play().act('prep', async () => {}, { skip: true }).run('label', { page });
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('⏭  prep  SKIPPED'));
   });
 
@@ -531,7 +592,7 @@ describe('Play logging', () => {
       .act('nav', async () => { throw new Error('boom'); })
       .act('prep', async () => {});
 
-    await expect(play.run('label', { page, state: null, result: null })).rejects.toThrow();
+    await expect(play.run('label', { page })).rejects.toThrow();
 
     expect(logSpy).toHaveBeenCalledWith(expect.stringMatching(/❌ nav/));
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('⏭  prep  SKIPPED'));
@@ -539,23 +600,23 @@ describe('Play logging', () => {
 
   it('logs ❌ for a failure outcome from attempt', async () => {
     const page = makePage();
-    mockAttemptAction.mockResolvedValueOnce({ isSuccess: false, outcome: 'blocked', data: undefined });
+    mockAttemptAction.mockResolvedValueOnce({ isSuccess: false, outcome: 'blocked', payload: undefined });
 
     const play = new Play().attempt(async () => {}, [Outcomes.failure(mockLocator)]);
 
-    await play.run('label', { page, state: null, result: null });
+    await play.run('label', { page });
 
     expect(logSpy).toHaveBeenCalledWith(expect.stringMatching(/❌ attempt.*outcome: blocked/));
   });
 
-  it('logs → state: <name> after detect', async () => {
+  it('logs → outcome: <name> after detect', async () => {
     const page = makePage();
-    mockDetectPageState.mockResolvedValue({ isSuccess: true, outcome: 'found', data: undefined });
+    mockDetectPageState.mockResolvedValue({ isSuccess: true, outcome: 'found', payload: undefined });
 
     const play = new Play().detect(() => [{ name: 'found', isSuccess: true, locator: mockLocator }]);
-    await play.run('label', { page, state: null, result: null });
+    await play.run('label', { page });
 
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('→ state: found'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('→ outcome: found'));
   });
 
   it('logs ⏭ cleanup SKIPPED when attempt was not reached', async () => {
@@ -564,7 +625,7 @@ describe('Play logging', () => {
       .act('nav', async () => {})
       .cleanup(async () => {});
 
-    await play.run('label', { page, state: null, result: null });
+    await play.run('label', { page });
 
     const calls = logSpy.mock.calls.map(c => c[0] as string);
     expect(calls.some(c => c.includes('cleanup'))).toBe(false);
@@ -572,14 +633,14 @@ describe('Play logging', () => {
 
   it('logs ⏭ cleanup SKIPPED when a prior act threw', async () => {
     const page = makePage();
-    mockAttemptAction.mockResolvedValueOnce({ isSuccess: true, outcome: 'ok', data: undefined });
+    mockAttemptAction.mockResolvedValueOnce({ isSuccess: true, outcome: 'ok', payload: undefined });
 
     const play = new Play()
       .attempt(async () => {}, [Outcomes.success(mockLocator)])
       .act('post', async () => { throw new Error('after attempt'); })
       .cleanup(async () => {});
 
-    await expect(play.run('label', { page, state: null, result: null })).rejects.toThrow();
+    await expect(play.run('label', { page })).rejects.toThrow();
 
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('⏭  cleanup  SKIPPED'));
   });

--- a/src/play.ts
+++ b/src/play.ts
@@ -1,6 +1,11 @@
-import type { Page } from '@playwright/test';
-import { attemptAction, detectPageState } from './attemptAction.js';
-import type { AttemptActionOptions, Outcome } from './attemptAction.js';
+import type { Locator, Page } from '@playwright/test';
+import {
+  attemptAction,
+  detectPageState,
+  type AttemptActionOptions,
+  type AttemptResolution,
+  type Outcome,
+} from './attemptAction.js';
 import type { OutcomeSpec } from './outcomes.js';
 
 export type { AttemptActionOptions } from './attemptAction.js';
@@ -15,23 +20,53 @@ export type DetectOptions = ActOptions & {
   timeout?: number;
 };
 
+/** One branch returned from the `.detect()` callback — forwarded to `detectPageState` / `attemptAction`. */
+export type DetectCandidate = {
+  name: string;
+  isSuccess: boolean;
+  locator?: Locator;
+  /**
+   * When this branch wins, called with the winning locator; return value becomes the next act’s
+   * third-argument `outcome.payload` (see {@link PlayOutcome}).
+   */
+  onOutcome?: (winner: Locator) => Promise<unknown>;
+};
+
+/**
+ * Resolved winner from the immediately previous `.detect()` or `.attempt()` (third argument to
+ * every act callback). Omitted / `undefined` when the previous act was not detect or attempt.
+ */
+export type PlayOutcome = {
+  name: string;
+  isSuccess: boolean;
+  locator?: Locator;
+  /** From the winning branch’s `onOutcome`, if defined; otherwise `undefined`. */
+  payload?: unknown;
+};
+
+/** Return value of {@link Play.run} — `lastOutcome` is the final detect/attempt resolution, if any. */
+export type PlayRunResult = {
+  ctx: PlayCtx;
+  lastOutcome?: PlayOutcome;
+};
+
+function outcomeFromResolution(res: AttemptResolution): PlayOutcome {
+  const o: PlayOutcome = {
+    name: res.outcome,
+    isSuccess: res.isSuccess,
+  };
+  if (res.payload !== undefined) o.payload = res.payload;
+  if (res.locator != null) o.locator = res.locator;
+  return o;
+}
+
 /** Mutable context object passed to every act function during play execution. */
 export type PlayCtx = {
-  /** Result of the most recent .detect() — winner's name and isSuccess. */
-  state: { name: string; isSuccess: boolean; data?: unknown } | null;
-  /** Result of the most recent .attempt() — set even on failure outcomes. */
-  result: { isSuccess: boolean; outcome: string; data?: unknown } | null;
   /** Arbitrary extra context from Playbook.withCtx() (e.g. table helpers). */
   [key: string]: unknown;
 };
 
-type ActFn = (page: Page, ctx: PlayCtx) => Promise<void>;
-
-type DetectCandidate = {
-  name: string;
-  isSuccess: boolean;
-  locator?: import('@playwright/test').Locator;
-};
+export type ActFn = (page: Page, ctx: PlayCtx, outcome: PlayOutcome | undefined) => Promise<void>;
 
 // ── Internal act record (discriminated union) ─────────────────────────────────
 
@@ -129,7 +164,7 @@ export class Play {
 
   // ── Execution ────────────────────────────────────────────────────────────────
 
-  async run(label: string, ctx: PlayCtx): Promise<PlayCtx> {
+  async run(label: string, ctx: PlayCtx): Promise<PlayRunResult> {
     const page = ctx['page'] as Page;
     if (!page) throw new Error(`[${label}] No page in PlayCtx — bind one via Playbook.withCtx({ page })`);
 
@@ -141,6 +176,7 @@ export class Play {
 
     let attemptReached = false;
     let runError: Error | undefined;
+    let lastOutcome: PlayOutcome | undefined;
 
     for (const act of mainActs) {
       const actName = _actLabel(act);
@@ -155,7 +191,7 @@ export class Play {
       try {
         switch (act.kind) {
           case 'act':
-            await act.fn(page, ctx);
+            await act.fn(page, ctx, lastOutcome);
             console.log(`  ✅ ${actName}  (${Date.now() - t}ms)`);
             break;
 
@@ -170,12 +206,13 @@ export class Play {
               name: c.name,
               isSuccess: c.isSuccess,
               ...(c.locator !== undefined && { locator: c.locator }),
+              ...(c.onOutcome !== undefined && { onOutcome: c.onOutcome }),
             }));
             const detectParams: Parameters<typeof detectPageState>[0] = { outcomes };
             if (act.timeout !== undefined) detectParams.timeout = act.timeout;
             const detectResult = await detectPageState(detectParams);
-            ctx['state'] = { name: detectResult.outcome, isSuccess: detectResult.isSuccess, data: detectResult.data };
-            console.log(`  ✅ ${actName}  (${Date.now() - t}ms) → state: ${detectResult.outcome}`);
+            lastOutcome = outcomeFromResolution(detectResult);
+            console.log(`  ✅ ${actName}  (${Date.now() - t}ms) → outcome: ${lastOutcome.name}`);
             break;
           }
 
@@ -197,12 +234,13 @@ export class Play {
             const attemptOpts: AttemptActionOptions | undefined =
               resolvedTimeout !== undefined ? { ...act.opts, timeout: resolvedTimeout } : act.opts;
 
+            const incoming = lastOutcome;
             const result = await attemptAction(
-              () => act.action(page, ctx),
+              () => act.action(page, ctx, incoming),
               resolvedOutcomes,
               attemptOpts
             );
-            ctx['result'] = result;
+            lastOutcome = outcomeFromResolution(result);
 
             const ms = Date.now() - t;
             if (result.isSuccess) {
@@ -233,7 +271,7 @@ export class Play {
 
         const t = Date.now();
         try {
-          await act.fn(page, ctx);
+          await act.fn(page, ctx, lastOutcome);
           console.log(`  ✅ cleanup  (${Date.now() - t}ms)`);
         } catch (err: unknown) {
           const ms = Date.now() - t;
@@ -250,16 +288,24 @@ export class Play {
     }
 
     if (runError) throw runError;
-    return ctx;
+
+    const result: PlayRunResult = { ctx };
+    if (lastOutcome !== undefined) result.lastOutcome = lastOutcome;
+    return result;
   }
 }
 
 function _actLabel(act: ActRecord): string {
   switch (act.kind) {
-    case 'act': return act.name;
-    case 'detect': return 'detect';
-    case 'attempt': return act.name;
-    case 'cleanup': return 'cleanup';
-    case 'reload': return 'reload';
+    case 'act':
+      return act.name;
+    case 'detect':
+      return 'detect';
+    case 'attempt':
+      return act.name;
+    case 'cleanup':
+      return 'cleanup';
+    case 'reload':
+      return 'reload';
   }
 }

--- a/src/playbook.ts
+++ b/src/playbook.ts
@@ -78,16 +78,14 @@ export class Playbook<TPlays extends PlaybookPlays = PlaybookPlays> {
   }
 
   /**
-   * Returns a PlayCtx derived from the bound context, with state and result
-   * initialised to null. Includes `page` so Play.run() can access it via ctx['page'].
+   * Returns a PlayCtx derived from the bound context. Includes `page` so Play.run()
+   * can access it via ctx['page'].
    */
   buildCtx(): PlayCtx {
     const { page: _page, ...rest } = this._ctx as PlaybookCtx;
     return {
       ...rest,
       page: _page,
-      state: null,
-      result: null,
     };
   }
 }

--- a/tests/director.spec.ts
+++ b/tests/director.spec.ts
@@ -28,9 +28,9 @@ const datasetPb = new Playbook('DatasetPlaybook', {
       { name: 'table', isSuccess: true, locator: page.locator('[data-component="TableHeadersComponent"]') },
     ], { timeout: 8000 })
     .attempt(
-      async (page, ctx) => {
-        const state = ctx['state'] as { name: string } | null;
-        const btnName = state?.name === 'empty' ? 'Empty dataset' : 'Dataset';
+      async (page, _ctx, outcome) => {
+        const branch = outcome?.name;
+        const btnName = branch === 'empty' ? 'Empty dataset' : 'Dataset';
         await page.getByRole('button', { name: btnName, exact: true }).click();
         await page.getByPlaceholder('Name').fill(name, { timeout: 3000 });
         await page.getByRole('button', { name: 'Create' }).click();
@@ -60,9 +60,8 @@ const datasetPb = new Playbook('DatasetPlaybook', {
         Outcomes.timeout(5000),
       ],
     )
-    .cleanup(async (page, ctx) => {
-      const result = ctx['result'] as { isSuccess: boolean } | null;
-      if (result?.isSuccess) {
+    .cleanup(async (page, _ctx, outcome) => {
+      if (outcome?.isSuccess) {
         await page.locator(`tr:has-text("${newName}")`).getByRole('button', { name: 'Row actions' }).click();
         await page.getByRole('menuitem', { name: 'Rename' }).click();
         await page.getByRole('textbox').fill(name);


### PR DESCRIPTION
## Summary

- **Breaking:** Removes `ctx.state`, `ctx.result`, and any `ctx.latestOutcome` pattern. Detect/attempt winners are only the **third callback argument** `(page, ctx, outcome)` with shape `{ name, isSuccess, locator?, payload? }`.
- **`Play.run()`** now returns **`{ ctx, lastOutcome? }`** (`PlayRunResult`) so callers like **`Director`** can read the final resolution without mutating context.
- **`attemptAction` / `detectPageState`:** return value uses **`payload`** (replaces `data`) and optional **`locator`** (`AttemptResolution`).
- **`PlayResult`:** uses **`payload`** instead of **`data`**.
- **Tests:** `tests/director.spec.ts` uses `outcome` in create/update cleanup; `src/play.test.ts` updated accordingly.

## Docs

- `docs/api/play.md`, `playbook.md`, `director.md`, `attempt-action.md`, `CHANGELOG.md`.

## Notes for follow-up

- **`wip/play-explorer`:** This PR targets `main` only. Play explorer–specific doc edits (`createTour.ts`, expanded `sugar-lab.md`) were left on your WIP branch; merge or cherry-pick `feat/play-outcome-api` into `wip/play-explorer` and re-apply those doc strings there if needed.
- **Stash:** If you still have stash `wip: play outcome + gitignore`, drop it after merging this branch into WIP to avoid re-applying the same patches.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated API docs and changelog: outcomes are now passed as a third callback argument (instead of being stored on context), payload replaces data, locator may be included, and run now returns updated result including last outcome.
* **Tests**
  * Updated and expanded tests to validate new outcome flow, callback signatures, payload forwarding, locator behavior, and run/cleanup semantics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-sugar/pull/26)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->