### PR TITLE
feat(playbook): add bindPlaybooks for multi-page catalog binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`bindPlaybooks(ctx, catalog)`** and **`BoundPlaybookCatalog<T>`** — bind a record of playbooks to one context in a single call (for example user vs admin pages without repeating `.withCtx` per playbook).
+
 ### Changed (breaking)
 
 - **`Play` / `PlayCtx`** — detect and attempt resolutions are no longer stored on `ctx.state` / `ctx.result` or on `ctx`. Use the **third callback argument** `(page, ctx, outcome)` on every act (`outcome` is `undefined` until after a `.detect()` or `.attempt()`). Shape: `{ name, isSuccess, locator?, payload? }` where `payload` is the winning branch’s `onOutcome` return. **`Play.run()`** returns `{ ctx, lastOutcome? }` so callers (e.g. `Director`) can read the final resolution without mutating context.

--- a/docs/api/playbook.md
+++ b/docs/api/playbook.md
@@ -49,6 +49,8 @@ Binds **every** playbook in a plain object to the **same** context (same as call
 ```ts
 import { bindPlaybooks, Director } from '@rickcedwhat/playwright-sugar';
 
+const director = new Director();
+
 const catalog = { dataset: datasetPb, logs: logsPb };
 const user = bindPlaybooks({ page: userPage }, catalog);
 const admin = bindPlaybooks({ page: adminPage }, catalog);
@@ -57,7 +59,7 @@ await director.ensureExists(admin.dataset, { name: 'x' });
 await director.assertCan(user.logs, 'access', {});
 ```
 
-`ctx` is a `Partial<PlaybookCtx>`: pass `{ page }` or `{ page, table, ... }` like `.withCtx()`. Return type preserves each playbook’s play typings (`BoundPlaybookCatalog`).
+`ctx` is a `Partial<PlaybookCtx>`: pass `{ page }` or `{ page, table, ... }` like `.withCtx()`. Return type preserves each playbook’s play typings (`BoundPlaybookCatalog`). The snippet assumes `datasetPb`, `logsPb`, `userPage`, and `adminPage` are already in scope (for example from your test or page-object setup).
 
 ## .getPlay(name)
 

--- a/docs/api/playbook.md
+++ b/docs/api/playbook.md
@@ -42,6 +42,23 @@ Extra keys are available in every act function via `ctx`:
 })
 ```
 
+## `bindPlaybooks(ctx, catalog)`
+
+Binds **every** playbook in a plain object to the **same** context (same as calling `.withCtx(ctx)` on each). Use this when you maintain one catalog of playbooks and two (or more) roles/pages — for example `user` and `admin` — so tests do not repeat `.withCtx({ page: … })` per resource.
+
+```ts
+import { bindPlaybooks, Director } from '@rickcedwhat/playwright-sugar';
+
+const catalog = { dataset: datasetPb, logs: logsPb };
+const user = bindPlaybooks({ page: userPage }, catalog);
+const admin = bindPlaybooks({ page: adminPage }, catalog);
+
+await director.ensureExists(admin.dataset, { name: 'x' });
+await director.assertCan(user.logs, 'access', {});
+```
+
+`ctx` is a `Partial<PlaybookCtx>`: pass `{ page }` or `{ page, table, ... }` like `.withCtx()`. Return type preserves each playbook’s play typings (`BoundPlaybookCatalog`).
+
 ## .getPlay(name)
 
 Returns the play factory for the given name. Throws if the play doesn't exist.

--- a/src/playbook.test.ts
+++ b/src/playbook.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Page } from '@playwright/test';
+import { Play } from './play.js';
+import { Playbook, bindPlaybooks } from './playbook.js';
+
+function makePage(label: string): Page {
+  return {
+    bringToFront: vi.fn().mockResolvedValue(undefined),
+    toString: () => label,
+  } as unknown as Page;
+}
+
+describe('bindPlaybooks', () => {
+  it('returns distinct bound instances per page', () => {
+    const pageA = makePage('A');
+    const pageB = makePage('B');
+    const base = new Playbook('X', {
+      p: () => new Play(),
+    });
+    const catalog = { one: base, two: base };
+
+    const boundA = bindPlaybooks({ page: pageA }, catalog);
+    const boundB = bindPlaybooks({ page: pageB }, catalog);
+
+    expect(boundA.one).not.toBe(base);
+    expect(boundA.one).not.toBe(boundB.one);
+    expect(boundA.one.getPage()).toBe(pageA);
+    expect(boundB.one.getPage()).toBe(pageB);
+  });
+
+  it('merges extra ctx keys onto each playbook', () => {
+    const page = makePage('P');
+    const table = { id: 't1' };
+    const base = new Playbook('Y', { p: () => new Play() });
+    const bound = bindPlaybooks({ page, table }, { only: base });
+    const ctx = bound.only.buildCtx();
+    expect(ctx['page']).toBe(page);
+    expect(ctx['table']).toEqual(table);
+  });
+});

--- a/src/playbook.ts
+++ b/src/playbook.ts
@@ -18,6 +18,38 @@ export type PlaybookCtx = {
   [key: string]: unknown;
 };
 
+/**
+ * Result of {@link bindPlaybooks}: same keys as the input catalog, each playbook
+ * merged with the shared context (preserves per-playbook play typings).
+ */
+export type BoundPlaybookCatalog<T extends Record<string, Playbook>> = {
+  [K in keyof T]: T[K] extends Playbook<infer P> ? Playbook<P> : Playbook;
+};
+
+/**
+ * Binds every playbook in `catalog` to the same context via {@link Playbook.withCtx}.
+ * Typical use: one object for “user” and one for “admin”, without repeating `.withCtx`.
+ *
+ * @example
+ * ```ts
+ * const catalog = { project: projectPb, logs: logsPb };
+ * const user = bindPlaybooks({ page: userPage }, catalog);
+ * const admin = bindPlaybooks({ page: adminPage }, catalog);
+ * await director.ensureExists(admin.project, { name: 'x' });
+ * await director.assertCan(user.logs, 'access', {});
+ * ```
+ */
+export function bindPlaybooks<T extends Record<string, Playbook>>(
+  ctx: Partial<PlaybookCtx>,
+  catalog: T
+): BoundPlaybookCatalog<T> {
+  const out = {} as BoundPlaybookCatalog<T>;
+  for (const key of Object.keys(catalog) as (keyof T & string)[]) {
+    (out as Record<string, Playbook>)[key] = catalog[key]!.withCtx(ctx);
+  }
+  return out;
+}
+
 // ── Playbook ──────────────────────────────────────────────────────────────────
 
 export class Playbook<TPlays extends PlaybookPlays = PlaybookPlays> {


### PR DESCRIPTION
## Summary

Adds **`bindPlaybooks(ctx, catalog)`** and **`BoundPlaybookCatalog<T>`** so tests (or page objects) can bind a **single catalog** of playbooks to **each role’s page** in one call, instead of repeating `.withCtx({ page })` per playbook.

## Changes

- `src/playbook.ts` — new helper and mapped return type (each entry is `catalog[key].withCtx(ctx)`).
- `src/playbook.test.ts` — Vitest coverage for distinct instances per page and merged extra ctx keys.
- `docs/api/playbook.md` — usage section and example.
- `CHANGELOG.md` — Unreleased entry.

## How to use

```ts
const catalog = { project: projectPb, logs: logsPb };
const user = bindPlaybooks({ page: userPage }, catalog);
const admin = bindPlaybooks({ page: adminPage }, catalog);
await director.ensureExists(admin.project, { name: 'x' });
await director.assertCan(user.logs, 'access', {});
```


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apply a shared context to an entire catalog of playbooks at once, while preserving each playbook’s typings.

* **Documentation**
  * Added API docs with usage examples showing separate pages (e.g., user vs admin) using the same playbook catalog.

* **Tests**
  * Added tests verifying distinct bound instances per page and correct merged context behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-sugar/pull/27)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->