### PR TITLE
feat(playbook): withCtx(name, ctx) log labels and bindPlaybooks { name }

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`bindPlaybooks(ctx, catalog)`** and **`BoundPlaybookCatalog<T>`** — bind a record of playbooks to one context in a single call (for example user vs admin pages without repeating `.withCtx` per playbook).
+- **`bindPlaybooks(ctx, catalog, opts?)`** — optional `{ name }` calls two-argument `withCtx(name, ctx)` per entry for readable multi-page logs.
+- **`Playbook.withCtx(name, ctx)` overload**, **`logScope()`**, **`runLabel(playName)`** — log prefix separate from registry `Playbook.name`; `Director` / `Play` labels use `scope > PlaybookName > playName`.
+- **Package entry** — explicit `bindPlaybooks` / `BoundPlaybookCatalog` / `BindPlaybooksOptions` re-exports from the root module.
 
 ### Changed (breaking)
 

--- a/docs/api/playbook.md
+++ b/docs/api/playbook.md
@@ -23,17 +23,24 @@ const datasetPb = new Playbook('DatasetPlaybook', {
 });
 ```
 
-## .withCtx(ctx)
+## .withCtx(ctx) / .withCtx(name, ctx)
 
 Returns a new Playbook with merged context. The original is unchanged. Must be called with at least `{ page }` before using `Director`.
 
+**One argument** — bind the page and any keys you need inside acts (`ctx['table']`, etc.):
+
 ```ts
 const pb = datasetPb.withCtx({ page });
-// with extra context
 const pbWithTable = datasetPb.withCtx({ page, table: braintrustTable });
 ```
 
-Extra keys are available in every act function via `ctx`:
+**Two arguments** — same as above, plus a **log-only** first segment for {@link Playbook.runLabel} (this `name` is **not** {@link Playbook.name}; the registry id still comes from `new Playbook('DatasetPlaybook', …)`):
+
+```ts
+datasetPb.withCtx('User', { page: userPage, table: braintrustTable });
+```
+
+Extra keys (other than the log label) are available in every act function via `ctx`:
 
 ```ts
 .nav(async (page, ctx) => {
@@ -42,7 +49,7 @@ Extra keys are available in every act function via `ctx`:
 })
 ```
 
-## `bindPlaybooks(ctx, catalog)`
+## `bindPlaybooks(ctx, catalog, opts?)`
 
 Binds **every** playbook in a plain object to the **same** context (same as calling `.withCtx(ctx)` on each). Use this when you maintain one catalog of playbooks and two (or more) roles/pages — for example `user` and `admin` — so tests do not repeat `.withCtx({ page: … })` per resource.
 
@@ -52,14 +59,18 @@ import { bindPlaybooks, Director } from '@rickcedwhat/playwright-sugar';
 const director = new Director();
 
 const catalog = { dataset: datasetPb, logs: logsPb };
-const user = bindPlaybooks({ page: userPage }, catalog);
-const admin = bindPlaybooks({ page: adminPage }, catalog);
+const user = bindPlaybooks({ page: userPage }, catalog, { name: 'User' });
+const admin = bindPlaybooks({ page: adminPage }, catalog, { name: 'Admin' });
 
 await director.ensureExists(admin.dataset, { name: 'x' });
 await director.assertCan(user.logs, 'access', {});
 ```
 
-`ctx` is a `Partial<PlaybookCtx>`: pass `{ page }` or `{ page, table, ... }` like `.withCtx()`. Return type preserves each playbook’s play typings (`BoundPlaybookCatalog`). The snippet assumes `datasetPb`, `logsPb`, `userPage`, and `adminPage` are already in scope (for example from your test or page-object setup).
+`ctx` is a `Partial<PlaybookCtx>`: pass `{ page }` or `{ page, table, ... }` like `.withCtx()`. Return type preserves each playbook’s play typings (`BoundPlaybookCatalog`). Optional third argument `{ name: 'User' }` is shorthand for two-argument `withCtx('User', { ...ctx })` on every catalog entry. The snippet assumes `datasetPb`, `logsPb`, `userPage`, and `adminPage` are already in scope (for example from your test or page-object setup).
+
+## .runLabel(playName)
+
+Returns the string passed to `Play.run` and used in `Director` errors: **`scope > playbookName > playName`** when `playbookLogScope` / `bindPlaybooks`’s `name` is set, otherwise **`playbookName > playName`**.
 
 ## .getPlay(name)
 
@@ -71,4 +82,4 @@ Returns the bound page. Throws if `.withCtx({ page })` has not been called.
 
 ## .buildCtx()
 
-Returns an initial `PlayCtx` from the bound context. Called internally by `Director`.
+Returns an initial `PlayCtx` from the bound context with `state` and `result` initialised to `null`. Strips **`playbookLogScope`** so act callbacks do not see log metadata. Called internally by `Director`.

--- a/src/director.ts
+++ b/src/director.ts
@@ -30,7 +30,7 @@ export class Director {
     const result = await this._runPlay(playbook, playName, params);
     if (!result.isSuccess) {
       throw new Error(
-        `[${playbook.name} > ${playName}] assertCan: expected success but got "${result.outcome}"`
+        `[${playbook.runLabel(playName)}] assertCan: expected success but got "${result.outcome}"`
       );
     }
     return result;
@@ -48,7 +48,7 @@ export class Director {
     const result = await this._runPlay(playbook, playName, params);
     if (result.isSuccess) {
       throw new Error(
-        `[${playbook.name} > ${playName}] assertCannot: expected failure but got success`
+        `[${playbook.runLabel(playName)}] assertCannot: expected failure but got success`
       );
     }
     return result;
@@ -85,8 +85,12 @@ export class Director {
       const strategy = opts.syncStrategy ?? SyncStrategy.default();
       await strategy.sync(opts.syncTo);
 
-      const targetPlaybook = playbook.withCtx({ page: opts.syncTo });
-      await this._retryExists(targetPlaybook, params, playbook.name);
+      const scope = playbook.logScope();
+      const targetPlaybook =
+        scope !== undefined
+          ? playbook.withCtx(scope, { page: opts.syncTo })
+          : playbook.withCtx({ page: opts.syncTo });
+      await this._retryExists(targetPlaybook, params, targetPlaybook.runLabel('exists'));
     }
   }
 
@@ -100,7 +104,7 @@ export class Director {
     const factory = playbook.getPlay(playName);
     const play = factory(params);
     const ctx = playbook.buildCtx();
-    const label = `${playbook.name} > ${playName}`;
+    const label = playbook.runLabel(playName);
 
     const { lastOutcome } = await play.run(label, ctx);
 
@@ -119,7 +123,7 @@ export class Director {
   private async _retryExists(
     playbook: Playbook,
     params: unknown,
-    originalName: string
+    existsLabel: string
   ): Promise<void> {
     const deadline = Date.now() + SYNC_RETRY_TIMEOUT;
     while (Date.now() < deadline) {
@@ -128,7 +132,7 @@ export class Director {
       await new Promise(resolve => setTimeout(resolve, SYNC_RETRY_INTERVAL));
     }
     throw new Error(
-      `[${originalName}] ensureExists: resource not found on sync target after ${SYNC_RETRY_TIMEOUT}ms`
+      `[${existsLabel}] ensureExists: resource not found on sync target after ${SYNC_RETRY_TIMEOUT}ms`
     );
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ export * from './clickToOpen.js';
 export * from './outcomes.js';
 export * from './play.js';
 export * from './playbook.js';
+export { bindPlaybooks } from './playbook.js';
+export type { BoundPlaybookCatalog, BindPlaybooksOptions } from './playbook.js';
 export * from './director.js';
 export * from './syncStrategy.js';
 export * from './verifiedFill.js';

--- a/src/play.test.ts
+++ b/src/play.test.ts
@@ -534,6 +534,20 @@ describe('Playbook.withCtx()', () => {
     expect(withPage2.getPage()).toBe(page2);
     expect(withPage1.getPage()).toBe(page1);
   });
+
+  it('two-arg withCtx sets log scope without changing registry name', () => {
+    const pb = new Playbook('MyPb', plays);
+    const page = makePage();
+    const bound = pb.withCtx('User', { page });
+    expect(bound.name).toBe('MyPb');
+    expect(bound.runLabel('exists')).toBe('User > MyPb > exists');
+  });
+
+  it('withCtx(name) without ctx throws', () => {
+    const pb = new Playbook('MyPb', plays);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => (pb as any).withCtx('User')).toThrow('ctx is required');
+  });
 });
 
 // ── Extra context propagates to acts ─────────────────────────────────────────

--- a/src/play.ts
+++ b/src/play.ts
@@ -166,7 +166,7 @@ export class Play {
 
   async run(label: string, ctx: PlayCtx): Promise<PlayRunResult> {
     const page = ctx['page'] as Page;
-    if (!page) throw new Error(`[${label}] No page in PlayCtx — bind one via Playbook.withCtx({ page })`);
+    if (!page) throw new Error(`[${label}] No page in PlayCtx — bind one via Playbook.withCtx({ page }) or .withCtx(name, { page })`);
 
     const mainActs = this._acts.filter(a => a.kind !== 'cleanup');
     const cleanupActs = this._acts.filter(a => a.kind === 'cleanup');

--- a/src/playbook.test.ts
+++ b/src/playbook.test.ts
@@ -37,4 +37,21 @@ describe('bindPlaybooks', () => {
     expect(ctx['page']).toBe(page);
     expect(ctx['table']).toEqual(table);
   });
+
+  it('sets log scope without renaming the playbook', () => {
+    const page = makePage('P');
+    const base = new Playbook('ProjectPlaybook', { p: () => new Play() });
+    const bound = bindPlaybooks({ page }, { project: base }, { name: 'User' });
+    expect(bound.project.name).toBe('ProjectPlaybook');
+    expect(bound.project.runLabel('create')).toBe('User > ProjectPlaybook > create');
+  });
+
+  it('does not put playbookLogScope into buildCtx', () => {
+    const page = makePage('P');
+    const base = new Playbook('Z', { p: () => new Play() });
+    const pb = base.withCtx('A', { page });
+    const ctx = pb.buildCtx();
+    expect(ctx['playbookLogScope']).toBeUndefined();
+    expect(pb.runLabel('p')).toBe('A > Z > p');
+  });
 });

--- a/src/playbook.ts
+++ b/src/playbook.ts
@@ -15,6 +15,11 @@ export type PlaybookPlays = Record<string, PlayFactory>;
  */
 export type PlaybookCtx = {
   page: Page;
+  /**
+   * Optional log label (set with two-argument `Playbook.withCtx(name, ctx)`).
+   * Stored internally; not passed into act `ctx` (see {@link Playbook.buildCtx}).
+   */
+  playbookLogScope?: string;
   [key: string]: unknown;
 };
 
@@ -27,25 +32,39 @@ export type BoundPlaybookCatalog<T extends Record<string, Playbook>> = {
 };
 
 /**
+ * Optional settings for {@link bindPlaybooks}.
+ */
+export type BindPlaybooksOptions = {
+  /**
+   * When set, equivalent to calling two-argument `withCtx(name, { ...ctx })` on each catalog entry
+   * (log label only; {@link Playbook.name} is unchanged).
+   */
+  name?: string;
+};
+
+/**
  * Binds every playbook in `catalog` to the same context via {@link Playbook.withCtx}.
  * Typical use: one object for “user” and one for “admin”, without repeating `.withCtx`.
  *
  * @example
  * ```ts
  * const catalog = { project: projectPb, logs: logsPb };
- * const user = bindPlaybooks({ page: userPage }, catalog);
- * const admin = bindPlaybooks({ page: adminPage }, catalog);
+ * const user = bindPlaybooks({ page: userPage }, catalog, { name: 'User' });
+ * const admin = bindPlaybooks({ page: adminPage }, catalog, { name: 'Admin' });
  * await director.ensureExists(admin.project, { name: 'x' });
  * await director.assertCan(user.logs, 'access', {});
  * ```
  */
 export function bindPlaybooks<T extends Record<string, Playbook>>(
   ctx: Partial<PlaybookCtx>,
-  catalog: T
+  catalog: T,
+  opts?: BindPlaybooksOptions
 ): BoundPlaybookCatalog<T> {
   const out = {} as BoundPlaybookCatalog<T>;
   for (const key of Object.keys(catalog) as (keyof T & string)[]) {
-    (out as Record<string, Playbook>)[key] = catalog[key]!.withCtx(ctx);
+    const original = catalog[key]!;
+    (out as Record<string, Playbook>)[key] =
+      opts?.name && opts.name.length > 0 ? original.withCtx(opts.name, ctx) : original.withCtx(ctx);
   }
   return out;
 }
@@ -53,7 +72,7 @@ export function bindPlaybooks<T extends Record<string, Playbook>>(
 // ── Playbook ──────────────────────────────────────────────────────────────────
 
 export class Playbook<TPlays extends PlaybookPlays = PlaybookPlays> {
-  /** Optional human-readable name used by Director in error labels. */
+  /** Registry id from `new Playbook(name, plays)`; middle segment of {@link Playbook.runLabel}. */
   readonly name: string;
   private readonly _plays: TPlays;
   private readonly _ctx: Partial<PlaybookCtx>;
@@ -74,13 +93,31 @@ export class Playbook<TPlays extends PlaybookPlays = PlaybookPlays> {
   /**
    * Returns a new Playbook with merged context. The original is unchanged.
    *
+   * Two forms:
+   * - `withCtx({ page, ... })` — bind page and optional act context.
+   * - `withCtx(name, { page, ... })` — same, plus a **log-only** first segment for {@link Playbook.runLabel}
+   *   (`name` is not the playbook registry id; that stays {@link Playbook.name}).
+   *
    * ```ts
-   * const userPb = datasetPb.withCtx({ page: userPage, table: braintrustTable });
+   * datasetPb.withCtx({ page: userPage, table: braintrustTable });
+   * datasetPb.withCtx('User', { page: userPage, table: braintrustTable });
    * ```
    */
-  withCtx(ctx: Partial<PlaybookCtx>): Playbook<TPlays> {
+  withCtx(ctx: Partial<PlaybookCtx>): Playbook<TPlays>;
+  withCtx(name: string, ctx: Partial<PlaybookCtx>): Playbook<TPlays>;
+  withCtx(nameOrCtx: string | Partial<PlaybookCtx>, maybeCtx?: Partial<PlaybookCtx>): Playbook<TPlays> {
+    if (typeof nameOrCtx === 'string') {
+      if (maybeCtx === undefined) {
+        throw new Error('Playbook.withCtx(name, ctx): ctx is required when name is provided');
+      }
+      return this.mergeCtx({ ...maybeCtx, playbookLogScope: nameOrCtx });
+    }
+    return this.mergeCtx(nameOrCtx);
+  }
+
+  private mergeCtx(partial: Partial<PlaybookCtx>): Playbook<TPlays> {
     const copy = new Playbook<TPlays>(this.name, this._plays);
-    (copy as unknown as { _ctx: Partial<PlaybookCtx> })['_ctx'] = { ...this._ctx, ...ctx };
+    (copy as unknown as { _ctx: Partial<PlaybookCtx> })['_ctx'] = { ...this._ctx, ...partial };
     return copy;
   }
 
@@ -103,21 +140,41 @@ export class Playbook<TPlays extends PlaybookPlays = PlaybookPlays> {
     const page = this._ctx['page'];
     if (!page) {
       throw new Error(
-        `Playbook "${this.name}" has no page bound — call .withCtx({ page }) before using Director`
+        `Playbook "${this.name}" has no page bound — call .withCtx({ page }) or .withCtx(name, { page }) before using Director`
       );
     }
     return page as Page;
   }
 
   /**
-   * Returns a PlayCtx derived from the bound context. Includes `page` so Play.run()
-   * can access it via ctx['page'].
+   * Log label from `withCtx(name, ctx)` / {@link bindPlaybooks} `opts`, if any.
+   */
+  logScope(): string | undefined {
+    const s = this._ctx['playbookLogScope'];
+    return typeof s === 'string' && s.length > 0 ? s : undefined;
+  }
+
+  /**
+   * Label passed to `Play.run` / used in `Director` errors: either
+   * `` `${logScope} > ${name} > ${playName}` `` or `` `${name} > ${playName}` ``.
+   */
+  runLabel(playName: string): string {
+    const scope = this.logScope();
+    if (scope !== undefined) {
+      return `${scope} > ${this.name} > ${playName}`;
+    }
+    return `${this.name} > ${playName}`;
+  }
+
+  /**
+   * Returns a PlayCtx derived from the bound context. Includes `page` so `Play.run()`
+   * can access it via `ctx['page']`. Omits {@link PlaybookCtx.playbookLogScope} so act callbacks stay free of log metadata.
    */
   buildCtx(): PlayCtx {
-    const { page: _page, ...rest } = this._ctx as PlaybookCtx;
+    const { page: _page, playbookLogScope: _omit, ...rest } = this._ctx as PlaybookCtx;
     return {
       ...rest,
       page: _page,
-    };
+    } as PlayCtx;
   }
 }


### PR DESCRIPTION
## Summary

- **`Playbook.withCtx(name, ctx)`** — optional first argument is a **log-only** label (separate from registry `Playbook.name`). Banners use **`runLabel(playName)`** → `User > DatasetPlaybook > exists` via `logScope()` / internal `playbookLogScope` (stripped from `buildCtx()` so acts stay clean).
- **`bindPlaybooks(ctx, catalog, opts?)`** — optional **`{ name }`** delegates to the two-argument `withCtx` per catalog entry.
- **`Director`** — `assertCan` / `assertCannot` / `_runPlay` use `runLabel`; **`ensureExists` + `syncTo`** rebinds the page while preserving `logScope` when present; sync retry errors use `runLabel('exists')`.
- **Root exports** — explicit `bindPlaybooks` / `BoundPlaybookCatalog` / `BindPlaybooksOptions` for editor resolution.
- **Docs & tests** — `docs/api/playbook.md`, Vitest (`playbook.test.ts`, `play.test.ts`), `Play` missing-page hint.

## Removed

- **`Playbook.withName`** — dropped in favor of log scope + constructor `name` only.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `Playbook.withCtx()` now supports an optional name parameter as the first argument.
  * `bindPlaybooks()` accepts an optional `{ name }` configuration.
  * Added `logScope()` and `runLabel()` methods to `Playbook`.

* **Documentation**
  * Updated API documentation for new `withCtx()` overload and `bindPlaybooks()` options.
  * Updated CHANGELOG with new bindings and APIs.

* **Tests**
  * Added unit tests for `withCtx()` name parameter and `bindPlaybooks()` naming configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-sugar/pull/28)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->