### PR TITLE
feat: hoverMenu() helper for flake-resistant nested menu navigation

### DIFF
--- a/src/hoverMenu.ts
+++ b/src/hoverMenu.ts
@@ -1,0 +1,97 @@
+import type { Locator } from '@playwright/test';
+
+export type HoverMenuOptions = {
+  /** Whether to click the final item in the chain. Default: `true`. */
+  click?: boolean;
+  /** Timeout in ms to wait for each next item to become visible. Default: `5000`. */
+  stepTimeout?: number;
+  /** Pause in ms after each hover before checking visibility. Default: `100`. */
+  stepDelay?: number;
+  /** How many times to re-hover a step before giving up. Default: `2`. */
+  retries?: number;
+};
+
+/**
+ * Navigates a chain of hover-triggered menu items reliably.
+ *
+ * Moves between triggers using an L-shaped path that stays within the open
+ * menu's bounding box, avoiding the diagonal moves that cause menus to close.
+ * Each step waits for the next item to be visible before proceeding.
+ *
+ * @param chain - Ordered locators to hover through; the last item is the target.
+ * @returns The final locator in the chain (already clicked unless `click: false`).
+ */
+export async function hoverMenu(chain: Locator[], options: HoverMenuOptions = {}): Promise<Locator> {
+  const { click = true, stepTimeout = 5000, stepDelay = 100, retries = 2 } = options;
+
+  if (chain.length === 0) throw new Error('hoverMenu: chain must contain at least one locator');
+
+  const page = chain[0]!.page();
+
+  // Activate the first item to open the initial menu
+  await chain[0]!.hover();
+
+  for (let i = 0; i < chain.length - 1; i++) {
+    const current = chain[i]!;
+    const next = chain[i + 1]!;
+
+    // Wait for next to become visible; re-hover current if it times out
+    let visible = false;
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      if (attempt > 0) {
+        await current.hover();
+        if (stepDelay > 0) await page.waitForTimeout(stepDelay);
+      }
+      try {
+        await next.waitFor({ state: 'visible', timeout: stepTimeout });
+        visible = true;
+        break;
+      } catch {
+        if (attempt === retries) break;
+      }
+    }
+
+    if (!visible) {
+      throw new Error(
+        `hoverMenu: step ${i} → ${i + 1} failed — next item never became visible after ${retries + 1} hover attempt(s). ` +
+        `Locator: ${next.toString()}`
+      );
+    }
+
+    // Navigate to next via L-shaped path to stay within open menu boundaries
+    await _safeMove(page, current, next);
+    if (stepDelay > 0) await page.waitForTimeout(stepDelay);
+  }
+
+  const last = chain[chain.length - 1]!;
+  if (click) await last.click();
+  return last;
+}
+
+async function _safeMove(
+  page: ReturnType<Locator['page']>,
+  from: Locator,
+  to: Locator
+): Promise<void> {
+  const fromBox = await from.boundingBox();
+  const toBox = await to.boundingBox();
+
+  if (!fromBox || !toBox) return;
+
+  const fromCx = fromBox.x + fromBox.width / 2;
+  const fromCy = fromBox.y + fromBox.height / 2;
+  const toCx = toBox.x + toBox.width / 2;
+  const toCy = toBox.y + toBox.height / 2;
+
+  const opensToRight = toBox.x > fromBox.x + fromBox.width / 2;
+
+  if (opensToRight) {
+    // Move horizontally first (stay in the menu row), then vertically into the submenu
+    await page.mouse.move(toCx, fromCy);
+    await page.mouse.move(toCx, toCy);
+  } else {
+    // Opens below — move vertically first, then horizontally
+    await page.mouse.move(fromCx, toCy);
+    await page.mouse.move(toCx, toCy);
+  }
+}

--- a/src/hoverMenu.ts
+++ b/src/hoverMenu.ts
@@ -30,6 +30,7 @@ export async function hoverMenu(chain: Locator[], options: HoverMenuOptions = {}
 
   // Activate the first item to open the initial menu
   await chain[0]!.hover();
+  if (stepDelay > 0) await page.waitForTimeout(stepDelay);
 
   for (let i = 0; i < chain.length - 1; i++) {
     const current = chain[i]!;
@@ -58,8 +59,9 @@ export async function hoverMenu(chain: Locator[], options: HoverMenuOptions = {}
       );
     }
 
-    // Navigate to next via L-shaped path to stay within open menu boundaries
+    // Navigate to next via L-shaped path, then explicitly hover to ensure its submenu opens
     await _safeMove(page, current, next);
+    await next.hover();
     if (stepDelay > 0) await page.waitForTimeout(stepDelay);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,4 +10,5 @@ export * from './director.js';
 export * from './syncStrategy.js';
 export * from './verifiedFill.js';
 export * from './findByScrolling.js';
+export * from './hoverMenu.js';
 export * from './strategies.js';

--- a/tests/hoverMenu.spec.ts
+++ b/tests/hoverMenu.spec.ts
@@ -95,10 +95,9 @@ test.describe('hoverMenu()', () => {
   test('two-level: navigates and clicks the target item', async ({ page }) => {
     await page.setContent(TWO_LEVEL_HTML);
 
-    let clicked = false;
-    await page.exposeFunction('onTableClick', () => { clicked = true; });
     await page.evaluate(() => {
-      document.getElementById('table')!.addEventListener('click', () => (window as any).onTableClick());
+      (window as any).__clicked = false;
+      document.getElementById('table')!.addEventListener('click', () => { (window as any).__clicked = true; });
     });
 
     await hoverMenu([
@@ -106,16 +105,15 @@ test.describe('hoverMenu()', () => {
       page.locator('#table'),
     ]);
 
-    expect(clicked).toBe(true);
+    await page.waitForFunction(() => (window as any).__clicked === true);
   });
 
   test('three-level: navigates through two submenus and clicks', async ({ page }) => {
     await page.setContent(THREE_LEVEL_HTML);
 
-    let clicked = false;
-    await page.exposeFunction('on3x3Click', () => { clicked = true; });
     await page.evaluate(() => {
-      document.getElementById('cell-3x3')!.addEventListener('click', () => (window as any).on3x3Click());
+      (window as any).__clicked = false;
+      document.getElementById('cell-3x3')!.addEventListener('click', () => { (window as any).__clicked = true; });
     });
 
     await hoverMenu([
@@ -124,7 +122,7 @@ test.describe('hoverMenu()', () => {
       page.locator('#cell-3x3'),
     ]);
 
-    expect(clicked).toBe(true);
+    await page.waitForFunction(() => (window as any).__clicked === true);
   });
 
   test('click: false — returns final locator without clicking it', async ({ page }) => {
@@ -148,24 +146,22 @@ test.describe('hoverMenu()', () => {
   test('single item chain: hovers and clicks without traversal', async ({ page }) => {
     await page.setContent(TWO_LEVEL_HTML);
 
-    let clicked = false;
-    await page.exposeFunction('onInsertClick', () => { clicked = true; });
     await page.evaluate(() => {
-      document.getElementById('insert')!.addEventListener('click', () => (window as any).onInsertClick());
+      (window as any).__clicked = false;
+      document.getElementById('insert')!.addEventListener('click', () => { (window as any).__clicked = true; });
     });
 
     await hoverMenu([page.locator('#insert')]);
 
-    expect(clicked).toBe(true);
+    await page.waitForFunction(() => (window as any).__clicked === true);
   });
 
   test('submenu-below: safe-path also works when submenu opens downward', async ({ page }) => {
     await page.setContent(BELOW_MENU_HTML);
 
-    let clicked = false;
-    await page.exposeFunction('onSaveClick', () => { clicked = true; });
     await page.evaluate(() => {
-      document.getElementById('save')!.addEventListener('click', () => (window as any).onSaveClick());
+      (window as any).__clicked = false;
+      document.getElementById('save')!.addEventListener('click', () => { (window as any).__clicked = true; });
     });
 
     await hoverMenu([
@@ -173,7 +169,7 @@ test.describe('hoverMenu()', () => {
       page.locator('#save'),
     ]);
 
-    expect(clicked).toBe(true);
+    await page.waitForFunction(() => (window as any).__clicked === true);
   });
 
   test('returns the final locator in the chain', async ({ page }) => {

--- a/tests/hoverMenu.spec.ts
+++ b/tests/hoverMenu.spec.ts
@@ -1,0 +1,209 @@
+import { test, expect } from '@playwright/test';
+import { hoverMenu } from '../src/index.js';
+
+// ── Shared menu fixture helpers ───────────────────────────────────────────────
+
+// JS-driven hover menus — more reliable than CSS :hover in headless Chromium.
+// Script must come AFTER the menu markup so querySelectorAll finds the elements.
+const MENU_JS = `
+  <script>
+    document.querySelectorAll('li').forEach(li => {
+      li.addEventListener('mouseenter', () => {
+        const sub = li.querySelector(':scope > ul');
+        if (sub) sub.style.display = 'block';
+      });
+      li.addEventListener('mouseleave', () => {
+        const sub = li.querySelector(':scope > ul');
+        if (sub) sub.style.display = '';
+      });
+    });
+  </script>
+`;
+
+const BASE_STYLE = `
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { padding: 40px; font-family: sans-serif; }
+    ul { list-style: none; }
+    .menu { position: relative; display: inline-block; }
+    .menu li { position: relative; }
+    .menu li a {
+      display: block; padding: 8px 16px; white-space: nowrap;
+      background: #eee; border: 1px solid #ccc; cursor: pointer;
+      user-select: none;
+    }
+    .submenu {
+      display: none; position: absolute;
+      left: 100%; top: 0;
+      min-width: 160px;
+    }
+    .submenu-below {
+      display: none; position: absolute;
+      top: 100%; left: 0;
+      min-width: 160px;
+    }
+  </style>
+`;
+
+const TWO_LEVEL_HTML = `
+  ${BASE_STYLE}
+  <ul class="menu">
+    <li><a id="insert">Insert</a>
+      <ul class="submenu">
+        <li><a id="table">Table</a></li>
+        <li><a id="image">Image</a></li>
+      </ul>
+    </li>
+  </ul>
+  ${MENU_JS}
+`;
+
+const THREE_LEVEL_HTML = `
+  ${BASE_STYLE}
+  <ul class="menu">
+    <li><a id="insert">Insert</a>
+      <ul class="submenu">
+        <li><a id="table">Table</a>
+          <ul class="submenu">
+            <li><a id="cell-3x3">3×3</a></li>
+            <li><a id="cell-5x5">5×5</a></li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+  </ul>
+  ${MENU_JS}
+`;
+
+const BELOW_MENU_HTML = `
+  ${BASE_STYLE}
+  <ul class="menu">
+    <li><a id="file">File</a>
+      <ul class="submenu-below">
+        <li><a id="save">Save</a></li>
+        <li><a id="export">Export</a></li>
+      </ul>
+    </li>
+  </ul>
+  ${MENU_JS}
+`;
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('hoverMenu()', () => {
+
+  test('two-level: navigates and clicks the target item', async ({ page }) => {
+    await page.setContent(TWO_LEVEL_HTML);
+
+    let clicked = false;
+    await page.exposeFunction('onTableClick', () => { clicked = true; });
+    await page.evaluate(() => {
+      document.getElementById('table')!.addEventListener('click', () => (window as any).onTableClick());
+    });
+
+    await hoverMenu([
+      page.locator('#insert'),
+      page.locator('#table'),
+    ]);
+
+    expect(clicked).toBe(true);
+  });
+
+  test('three-level: navigates through two submenus and clicks', async ({ page }) => {
+    await page.setContent(THREE_LEVEL_HTML);
+
+    let clicked = false;
+    await page.exposeFunction('on3x3Click', () => { clicked = true; });
+    await page.evaluate(() => {
+      document.getElementById('cell-3x3')!.addEventListener('click', () => (window as any).on3x3Click());
+    });
+
+    await hoverMenu([
+      page.locator('#insert'),
+      page.locator('#table'),
+      page.locator('#cell-3x3'),
+    ]);
+
+    expect(clicked).toBe(true);
+  });
+
+  test('click: false — returns final locator without clicking it', async ({ page }) => {
+    await page.setContent(TWO_LEVEL_HTML);
+
+    let clicked = false;
+    await page.exposeFunction('onTableClick', () => { clicked = true; });
+    await page.evaluate(() => {
+      document.getElementById('table')!.addEventListener('click', () => (window as any).onTableClick());
+    });
+
+    const result = await hoverMenu([
+      page.locator('#insert'),
+      page.locator('#table'),
+    ], { click: false });
+
+    expect(clicked).toBe(false);
+    await expect(result).toBeVisible();
+  });
+
+  test('single item chain: hovers and clicks without traversal', async ({ page }) => {
+    await page.setContent(TWO_LEVEL_HTML);
+
+    let clicked = false;
+    await page.exposeFunction('onInsertClick', () => { clicked = true; });
+    await page.evaluate(() => {
+      document.getElementById('insert')!.addEventListener('click', () => (window as any).onInsertClick());
+    });
+
+    await hoverMenu([page.locator('#insert')]);
+
+    expect(clicked).toBe(true);
+  });
+
+  test('submenu-below: safe-path also works when submenu opens downward', async ({ page }) => {
+    await page.setContent(BELOW_MENU_HTML);
+
+    let clicked = false;
+    await page.exposeFunction('onSaveClick', () => { clicked = true; });
+    await page.evaluate(() => {
+      document.getElementById('save')!.addEventListener('click', () => (window as any).onSaveClick());
+    });
+
+    await hoverMenu([
+      page.locator('#file'),
+      page.locator('#save'),
+    ]);
+
+    expect(clicked).toBe(true);
+  });
+
+  test('returns the final locator in the chain', async ({ page }) => {
+    await page.setContent(TWO_LEVEL_HTML);
+
+    const imageLocator = page.locator('#image');
+    const result = await hoverMenu([
+      page.locator('#insert'),
+      imageLocator,
+    ], { click: false });
+
+    // Same object reference — we return the locator passed in, not a new one
+    expect(result).toBe(imageLocator);
+  });
+
+  test('throws a descriptive error when a step times out', async ({ page }) => {
+    await page.setContent(TWO_LEVEL_HTML);
+
+    await expect(
+      hoverMenu([
+        page.locator('#insert'),
+        page.locator('#nonexistent'),
+      ], { stepTimeout: 500, retries: 1 })
+    ).rejects.toThrow(/hoverMenu: step 0 → 1 failed/);
+  });
+
+  test('empty chain throws immediately', async ({ page }) => {
+    await page.setContent('<div></div>');
+
+    await expect(hoverMenu([])).rejects.toThrow('hoverMenu: chain must contain at least one locator');
+  });
+
+});


### PR DESCRIPTION
## Summary

- Adds `hoverMenu(chain, opts?)` — a new standalone helper that navigates a chain of hover-triggered menu locators reliably
- Moves between triggers via an **L-shaped mouse path** that stays within the open menu's bounding box, preventing the diagonal moves that collapse submenus
- Each step polls for the next item's visibility before proceeding, with per-step timeout and configurable retries
- Works for arbitrarily deep chains (2-level, 3-level, N-level) and for both right-opening and below-opening submenus

## Implementation notes

- Direction auto-detected from bounding boxes: `opensToRight` → horizontal-first L-shape; opens-below → vertical-first
- Fixtures use JS `mouseenter`/`mouseleave` (not CSS `:hover`) — more reliable in headless Chromium
- Two root-cause bugs caught during testing: invalid CSS ID selector starting with digit (`#3x3`), and `position: relative` missing from nested `<li>` elements causing submenus to anchor to the wrong parent

## Test plan

- [x] Two-level: navigates and clicks target
- [x] Three-level: navigates through two submenus and clicks
- [x] `click: false` returns locator without clicking
- [x] Single-item chain: hovers and clicks directly
- [x] Submenu-below: L-shape works for downward-opening menus
- [x] Returns the exact locator instance passed in
- [x] Throws descriptive error when step times out after retries
- [x] Empty chain throws immediately

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Playwright helper to navigate multi-level hover-triggered menus with configurable click behavior, step timeout/delay, and automatic retry handling.
  * Improved error messages when a menu step fails to appear.

* **Tests**
  * Added comprehensive tests covering two- and three-level menus, downward-opening submenus, click/no-click behavior, empty-chain validation, and error-timeout cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-sugar/pull/30)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->