### PR TITLE
feat: watchFor — proactive polling helper for overlay handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,5 @@ export * from './syncStrategy.js';
 export * from './verifiedFill.js';
 export * from './findByScrolling.js';
 export * from './strategies.js';
+
+export * from './watchFor.js';

--- a/src/watchFor.test.ts
+++ b/src/watchFor.test.ts
@@ -60,6 +60,19 @@ describe('watchFor', () => {
     expect(callback.mock.calls.length).toBe(countAtStop);
   });
 
+  it('continues polling after callback rejection', async () => {
+    const locator = makeLocator(true);
+    const callback = vi.fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValue(undefined);
+
+    const stop = watchFor(locator, callback, { interval: 10 });
+    await vi.advanceTimersByTimeAsync(25);
+    stop();
+
+    expect(callback.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
   it('defaults to 500ms interval', async () => {
     const locator = makeLocator(true);
     const callback = vi.fn().mockResolvedValue(undefined);
@@ -74,5 +87,22 @@ describe('watchFor', () => {
     await vi.advanceTimersByTimeAsync(1);   // 500ms elapsed — second iteration
     expect(callback).toHaveBeenCalledTimes(2);
     stop();
+  });
+
+  it('falls back to 500ms for invalid interval values', async () => {
+    const locator = makeLocator(true);
+    const callback = vi.fn().mockResolvedValue(undefined);
+
+    for (const bad of [0, -1, NaN, Infinity, -Infinity]) {
+      callback.mockClear();
+      const stop = watchFor(locator, callback, { interval: bad });
+      await vi.advanceTimersByTimeAsync(0);   // first iteration
+      expect(callback).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(499); // still on 500ms default
+      expect(callback).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);   // 500ms — fires again
+      expect(callback).toHaveBeenCalledTimes(2);
+      stop();
+    }
   });
 });

--- a/src/watchFor.test.ts
+++ b/src/watchFor.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Locator } from '@playwright/test';
+import { watchFor } from './watchFor.js';
+
+function makeLocator(visible: boolean): Locator {
+  return {
+    isVisible: vi.fn().mockResolvedValue(visible),
+  } as unknown as Locator;
+}
+
+beforeEach(() => { vi.useFakeTimers(); });
+afterEach(() => { vi.useRealTimers(); });
+
+describe('watchFor', () => {
+  it('calls callback when locator is visible', async () => {
+    const locator = makeLocator(true);
+    const callback = vi.fn().mockResolvedValue(undefined);
+
+    const stop = watchFor(locator, callback, { interval: 10 });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(callback).toHaveBeenCalledWith(locator);
+    expect(callback).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it('skips callback when locator is not visible', async () => {
+    const locator = makeLocator(false);
+    const callback = vi.fn();
+
+    const stop = watchFor(locator, callback, { interval: 10 });
+    await vi.advanceTimersByTimeAsync(50);
+    stop();
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('polls repeatedly on the configured interval', async () => {
+    const locator = makeLocator(true);
+    const callback = vi.fn().mockResolvedValue(undefined);
+
+    const stop = watchFor(locator, callback, { interval: 10 });
+    await vi.advanceTimersByTimeAsync(35);
+    stop();
+
+    expect(callback.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('stops polling after stop() is called', async () => {
+    const locator = makeLocator(true);
+    const callback = vi.fn().mockResolvedValue(undefined);
+
+    const stop = watchFor(locator, callback, { interval: 10 });
+    await vi.advanceTimersByTimeAsync(0);
+    stop();
+    const countAtStop = callback.mock.calls.length;
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(callback.mock.calls.length).toBe(countAtStop);
+  });
+
+  it('defaults to 500ms interval', async () => {
+    const locator = makeLocator(true);
+    const callback = vi.fn().mockResolvedValue(undefined);
+
+    const stop = watchFor(locator, callback);
+    await vi.advanceTimersByTimeAsync(0);   // first iteration (immediate)
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(499); // not yet
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);   // 500ms elapsed — second iteration
+    expect(callback).toHaveBeenCalledTimes(2);
+    stop();
+  });
+});

--- a/src/watchFor.ts
+++ b/src/watchFor.ts
@@ -16,12 +16,17 @@ export function watchFor(
   opts?: WatchForOptions
 ): () => void {
   let active = true;
-  const interval = opts?.interval ?? 500;
+  const raw = opts?.interval;
+  const interval = (Number.isFinite(raw) && raw! > 0) ? raw! : 500;
 
   const poll = async () => {
     while (active) {
-      if (await locator.isVisible()) {
-        await callback(locator);
+      try {
+        if (await locator.isVisible()) {
+          await callback(locator);
+        }
+      } catch {
+        // transient errors (e.g. element detached between isVisible and callback) don't stop polling
       }
       await new Promise<void>(resolve => setTimeout(resolve, interval));
     }

--- a/src/watchFor.ts
+++ b/src/watchFor.ts
@@ -1,0 +1,33 @@
+import type { Locator } from '@playwright/test';
+
+export type WatchForOptions = {
+  interval?: number;
+};
+
+/**
+ * Polls a locator and calls `callback` each time it's visible.
+ * Returns a stop function that halts polling after the current iteration completes.
+ *
+ * The callback is responsible for its own error handling.
+ */
+export function watchFor(
+  locator: Locator,
+  callback: (el: Locator) => Promise<void>,
+  opts?: WatchForOptions
+): () => void {
+  let active = true;
+  const interval = opts?.interval ?? 500;
+
+  const poll = async () => {
+    while (active) {
+      if (await locator.isVisible()) {
+        await callback(locator);
+      }
+      await new Promise<void>(resolve => setTimeout(resolve, interval));
+    }
+  };
+
+  poll();
+
+  return () => { active = false; };
+}


### PR DESCRIPTION
## Summary

- Adds `watchFor(locator, callback, opts?)` — polls a locator every 500ms (configurable via `opts.interval`) and calls `callback` each time it's visible
- Returns a `stop()` function to halt polling after the current iteration completes
- Callback is responsible for its own error handling — `watchFor` does not swallow errors
- Exported from the main package index

## Motivation

`addLocatorHandler` is action-gated — it only fires when a Playwright action (click, fill, expect) is blocked. Overlays that appear during passive waits, page loads, or between actions are invisible to it. `watchFor` polls continuously and handles them regardless of what Playwright is doing.

Closes #7

## Test plan

- [ ] `pnpm run test:unit` — 5 new tests covering visible/invisible behavior, repeated polling, stop(), and the 500ms default interval

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a utility to poll element visibility and invoke an async callback when visible; supports configurable polling intervals (with sensible defaults), resilient retrying, and a stop control.

* **Tests**
  * Added comprehensive tests covering visibility detection, interval handling (including invalid values), repeated polling, cancellation, error resilience, and timer behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-sugar/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->