### PR TITLE
feat: rename detectPageState → detectState, warn on empty relator

### DIFF
--- a/src/attemptAction.ts
+++ b/src/attemptAction.ts
@@ -9,7 +9,7 @@ export type Outcome = {
   onOutcome?: (winner: Locator) => Promise<unknown>;
 };
 
-/** Resolution from {@link attemptAction} / {@link detectPageState} — maps to {@link PlayOutcome}. */
+/** Resolution from {@link attemptAction} / {@link detectState} — maps to {@link PlayOutcome}. */
 export type AttemptResolution = {
   isSuccess: boolean;
   outcome: string;
@@ -159,7 +159,7 @@ ${errorMsg}
   throw new Error(errorMessage);
 }
 
-export async function detectPageState(params: {
+export async function detectState(params: {
   outcomes: Outcome[];
   timeout?: number;
 }) {

--- a/src/play.test.ts
+++ b/src/play.test.ts
@@ -9,20 +9,20 @@ import { Outcomes } from './outcomes.js';
 
 vi.mock('./attemptAction.js', () => ({
   attemptAction: vi.fn(),
-  detectPageState: vi.fn(),
+  detectState: vi.fn(),
 }));
 
-import { attemptAction, detectPageState } from './attemptAction.js';
+import { attemptAction, detectState } from './attemptAction.js';
 
 const mockAttemptAction = attemptAction as unknown as MockInstance;
-const mockDetectPageState = detectPageState as unknown as MockInstance;
+const mockDetectState = detectState as unknown as MockInstance;
 
 // Suppress play logging in tests
 beforeAll(() => { vi.spyOn(console, 'log').mockImplementation(() => {}); });
 afterAll(() => { vi.restoreAllMocks(); });
 beforeEach(() => {
   mockAttemptAction.mockReset();
-  mockDetectPageState.mockReset();
+  mockDetectState.mockReset();
 });
 
 function makePage(overrides: Partial<Record<string, unknown>> = {}): Page {
@@ -150,7 +150,7 @@ describe('.reload()', () => {
 
 describe('.detect() run result and third arg', () => {
   beforeEach(() => {
-    mockDetectPageState.mockResolvedValue({ isSuccess: true, outcome: 'found', payload: undefined });
+    mockDetectState.mockResolvedValue({ isSuccess: true, outcome: 'found', payload: undefined });
   });
 
   it('play.run returns lastOutcome from detect', async () => {
@@ -165,9 +165,9 @@ describe('.detect() run result and third arg', () => {
     expect(lastOutcome).toMatchObject({ name: 'found', isSuccess: true });
   });
 
-  it('forwards optional onOutcome on detect candidates to detectPageState outcomes', async () => {
+  it('forwards optional onOutcome on detect candidates to detectState outcomes', async () => {
     const page = makePage();
-    mockDetectPageState.mockResolvedValue({ isSuccess: true, outcome: 'a', payload: { picked: true } });
+    mockDetectState.mockResolvedValue({ isSuccess: true, outcome: 'a', payload: { picked: true } });
 
     const onOutcome = vi.fn().mockResolvedValue({ picked: true });
     const play = new Play().detect(() => [
@@ -176,7 +176,7 @@ describe('.detect() run result and third arg', () => {
 
     await play.run('label', { page });
 
-    expect(mockDetectPageState).toHaveBeenCalledWith(
+    expect(mockDetectState).toHaveBeenCalledWith(
       expect.objectContaining({
         outcomes: [
           expect.objectContaining({
@@ -275,7 +275,7 @@ describe('.attempt() and .cleanup()', () => {
 
   it('attempt trigger receives prior detect outcome as third argument', async () => {
     const page = makePage();
-    mockDetectPageState.mockResolvedValueOnce({
+    mockDetectState.mockResolvedValueOnce({
       isSuccess: true,
       outcome: 'empty',
       payload: 7,
@@ -625,7 +625,7 @@ describe('Play logging', () => {
 
   it('logs → outcome: <name> after detect', async () => {
     const page = makePage();
-    mockDetectPageState.mockResolvedValue({ isSuccess: true, outcome: 'found', payload: undefined });
+    mockDetectState.mockResolvedValue({ isSuccess: true, outcome: 'found', payload: undefined });
 
     const play = new Play().detect(() => [{ name: 'found', isSuccess: true, locator: mockLocator }]);
     await play.run('label', { page });

--- a/src/play.ts
+++ b/src/play.ts
@@ -1,7 +1,7 @@
 import type { Locator, Page } from '@playwright/test';
 import {
   attemptAction,
-  detectPageState,
+  detectState,
   type AttemptActionOptions,
   type AttemptResolution,
   type Outcome,
@@ -20,7 +20,7 @@ export type DetectOptions = ActOptions & {
   timeout?: number;
 };
 
-/** One branch returned from the `.detect()` callback — forwarded to `detectPageState` / `attemptAction`. */
+/** One branch returned from the `.detect()` callback — forwarded to `detectState` / `attemptAction`. */
 export type DetectCandidate = {
   name: string;
   isSuccess: boolean;
@@ -208,9 +208,9 @@ export class Play {
               ...(c.locator !== undefined && { locator: c.locator }),
               ...(c.onOutcome !== undefined && { onOutcome: c.onOutcome }),
             }));
-            const detectParams: Parameters<typeof detectPageState>[0] = { outcomes };
+            const detectParams: Parameters<typeof detectState>[0] = { outcomes };
             if (act.timeout !== undefined) detectParams.timeout = act.timeout;
-            const detectResult = await detectPageState(detectParams);
+            const detectResult = await detectState(detectParams);
             lastOutcome = outcomeFromResolution(detectResult);
             console.log(`  ✅ ${actName}  (${Date.now() - t}ms) → outcome: ${lastOutcome.name}`);
             break;

--- a/src/relator.ts
+++ b/src/relator.ts
@@ -10,18 +10,33 @@ export function relator(
   container?: Locator,
 ): Locator {
   const page = anchor.page();
+  let result: Locator;
 
   if (container) {
-    return container.filter({ has: anchor }).last().locator(target);
+    result = container.filter({ has: anchor }).last().locator(target);
+  } else {
+    // Find the smallest shared parent using a global search.
+    // This allows anchor and target to be pre-scoped locators (like dialog.getByText)
+    // without triggering a "nested" search in the .filter({ has: ... }) call.
+    result = page
+      .locator('*')
+      .filter({ has: anchor })
+      .filter({ has: target })
+      .last()
+      .locator(target);
   }
 
-  // Find the smallest shared parent using a global search.
-  // This allows anchor and target to be pre-scoped locators (like dialog.getByText)
-  // without triggering a "nested" search in the .filter({ has: ... }) call.
-  return page
-    .locator('*')
-    .filter({ has: anchor })
-    .filter({ has: target })
-    .last()
-    .locator(target);
+  void result.count().then(count => {
+    if (count === 0) {
+      console.warn(
+        '[relator] No elements found. ' +
+        'If `target` was created from a sub-element locator (e.g. row.locator(...)), ' +
+        'try using page.locator() or page.getByRole() instead.'
+      );
+    }
+  }).catch(() => {
+    // ignore — locator may not be resolvable (page not yet navigated, etc.)
+  });
+
+  return result;
 }


### PR DESCRIPTION
## Summary

- **`detectPageState` → `detectState`** (breaking rename, v0) — shorter name, consistent with the rest of the library. Closes #18
- **`relator` scope warning** — fires a `console.warn` when `count()` resolves to 0, hinting that `target` may have been created from a sub-element locator instead of `page.locator()` / `page.getByRole()`. Relates to #34

## Notes on the relator warning

`count()` in Playwright is immediate (no retry/wait), so the check is fire-and-forget and doesn't affect the returned locator or block the test. The warning is most useful when `relator` is called after navigation (the typical case). If called before the page loads, `count()` returns 0 for an unrelated reason — the `.catch()` path silently swallows that.

## Test plan

- [ ] `pnpm run test:unit` — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error diagnostics by adding warnings when element selectors fail to match any elements, making it easier to identify and resolve selection issues.

* **Refactor**
  * Updated internal state detection function naming to improve API clarity and consistency across the framework.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-sugar/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->