### PR TITLE
ci: always run unit tests as a required merge gate

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -59,8 +59,6 @@ jobs:
 
   unit-tests:
     name: Unit Tests (Vitest)
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code


### PR DESCRIPTION
## Summary

- Removes the `needs: changes` / `if: needs.changes.outputs.code == 'true'` condition from the `unit-tests` job
- Unit tests now run on every PR regardless of which paths changed
- Required so branch protection can reliably require this check — skipped jobs appear as \"missing\" to GitHub, not \"passing\"

## Test plan

- [ ] Confirm `Unit Tests (Vitest)` check appears on this PR and passes
- [ ] After merge, enable branch protection requiring this check on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration for unit test execution in pull request checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-sugar/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->