### PR TITLE
feat: poc sync retry loop and timeout fixes

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,7 @@ This document tracks future "Sugar" helpers and architectural improvements plann
 - **Goal**: A helper that waits for a specific duration of network inactivity or for specific "Busy" APIs to finish.
 
 ## 🏗️ Architectural Ideas
+- **Director-Registered Routines**: Decouple multi-play workflows (like `ensureExists`) from the Director core by registering workflows as routines. Tracked in [issue #42](https://github.com/rickcedwhat/playwright-sugar/issues/42).
 - **Global Error Handling**: Automatically capturing browser logs and screenshots ONLY on `attemptAction` failures.
 - **Automatic Retries for `verifiedFill`**: Enhancing `verifiedFill` to handle more complex state-reversion cases in specific frameworks.
 - **Plugin System**: Allowing users to register global "Cleaners" that run before every `attemptAction`.

--- a/docs/.vitepress/theme/components/PlayExplorer.vue
+++ b/docs/.vitepress/theme/components/PlayExplorer.vue
@@ -259,7 +259,7 @@ function goNextManual(): void {
 }
 
 const picksSummary = computed(() => {
-  const bits: { k: string; v: string }[] = [
+  const bits: { k: string; v: string | null }[] = [
     { k: 'Role', v: role.value },
     { k: 'Detect', v: detect.value },
     { k: 'Outcome rehearsal', v: outcome.value },

--- a/docs/api/play.md
+++ b/docs/api/play.md
@@ -10,7 +10,25 @@ new Play()
 
 ## Step builders
 
-All builders except `.attempt()` accept an optional `ActOptions` as their last argument: `{ skip?: boolean }`.
+All builders except `.attempt()` accept an optional `ActOptions` as their last argument:
+
+```ts
+type ActOptions = {
+  skip?: boolean | ((ctx: PlayCtx, lastOutcome?: PlayOutcome) => boolean);
+};
+```
+
+Pass a plain boolean to skip statically, or a predicate to decide at runtime based on context or the previous act's outcome:
+
+```ts
+// Static skip
+new Play().nav(async page => { /* ... */ }, { skip: !shouldNavigate })
+
+// Predicate skip — skip the cleanup revert if we know the attempt already failed
+new Play().cleanup(async (page, _ctx, outcome) => {
+  // revert logic
+}, { skip: (_ctx, lastOutcome) => lastOutcome?.isSuccess !== true })
+```
 
 ### .nav(fn, opts?)
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "test": "playwright test",
     "build": "pnpm exec tsc",
+    "poc": "pnpm --dir test-replacement-poc/PoC run poc",
     "prepare": "husky",
     "prepublishOnly": "pnpm run build",
     "test:unit": "vitest run",

--- a/src/attemptAction.ts
+++ b/src/attemptAction.ts
@@ -1,6 +1,6 @@
 import type { Locator } from '@playwright/test';
 
-export type AsyncLocatorFn = () => Locator | Promise<Locator>;
+export type AsyncLocatorFn = () => Locator | null | Promise<Locator | null>;
 
 export type Outcome = {
   name: string;

--- a/src/attemptAction.ts
+++ b/src/attemptAction.ts
@@ -22,6 +22,7 @@ export type AttemptResolution = {
 /** Options for `attemptAction` / `Play.attempt` — extend with future flags without breaking the positional API. */
 export type AttemptActionOptions = {
   timeout?: number;
+  ambiguityBufferMs?: number;
 };
 
 export async function attemptAction(
@@ -45,33 +46,37 @@ export async function attemptAction(
   const strictModeErrorsLogged = new Set<string>();
 
   // Polling Phase
-  while (Date.now() - startTime < timeout) {
-    const results = await Promise.all(
-      normalizedOutcomes.map(async (o) => {
-        try {
-          if (!o.locator) return { outcome: o, isVisible: false, locator: null };
-          
-          let actualLocator: Locator | null = null;
-          if (typeof o.locator === 'function') {
-            actualLocator = await o.locator();
-          } else {
-            actualLocator = o.locator;
-          }
+  const bufferMs = opts?.ambiguityBufferMs ?? 150;
+  
+  type Winner = { outcome: Outcome; locator: Locator };
+  let firstWinner: Winner | null = null;
+  const winners: Winner[] = [];
 
-          if (!actualLocator) return { outcome: o, isVisible: false, locator: null };
-          
-          const isVisible = await actualLocator.isVisible();
-          return { outcome: o, isVisible, locator: actualLocator };
-        } catch (error: unknown) {
-          const errorMsg = error instanceof Error ? error.message : '';
-          const isStrictModeError =
-            errorMsg.includes("strict mode violation") ||
-            (errorMsg.includes("resolved to") && errorMsg.includes("elements")) ||
-            errorMsg.includes("expected single element");
+  const candidatePromises = normalizedOutcomes.map(async (o) => {
+    while (Date.now() - startTime < timeout) {
+      try {
+        if (!o.locator) return null;
+        
+        let actualLocator: Locator | null = null;
+        if (typeof o.locator === 'function') {
+          actualLocator = await o.locator();
+        } else {
+          actualLocator = o.locator;
+        }
 
-          if (isStrictModeError && !strictModeErrorsLogged.has(o.name)) {
-            strictModeErrorsLogged.add(o.name);
-            console.error(`
+        if (actualLocator && await actualLocator.isVisible()) {
+          return { outcome: o, locator: actualLocator };
+        }
+      } catch (error: unknown) {
+        const errorMsg = error instanceof Error ? error.message : '';
+        const isStrictModeError =
+          errorMsg.includes("strict mode violation") ||
+          (errorMsg.includes("resolved to") && errorMsg.includes("elements")) ||
+          errorMsg.includes("expected single element");
+
+        if (isStrictModeError && !strictModeErrorsLogged.has(o.name)) {
+          strictModeErrorsLogged.add(o.name);
+          console.error(`
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ⚠️  STRICT MODE VIOLATION DETECTED
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -87,66 +92,65 @@ ${errorMsg}
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 `);
-          }
-          return { outcome: o, isVisible: false, locator: null };
         }
-      })
-    );
-
-    const winners = results.filter((r) => r.isVisible);
-
-    if (winners.length > 0) {
-      // Collision Policing
+      }
+      
       await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    return null;
+  });
 
-      const secondCheck = await Promise.all(
-        normalizedOutcomes.map(async (o) => {
-          try {
-            if (!o.locator) return { outcome: o, isVisible: false, locator: null };
-            let actualLocator: Locator | null = null;
-            if (typeof o.locator === 'function') {
-              actualLocator = await o.locator();
-            } else {
-              actualLocator = o.locator;
-            }
-            if (!actualLocator) return { outcome: o, isVisible: false, locator: null };
-            const isVisible = await actualLocator.isVisible();
-            return { outcome: o, isVisible, locator: actualLocator };
-          } catch (e) {
-            return { outcome: o, isVisible: false, locator: null };
-          }
-        })
-      );
-
-      const realWinners = secondCheck.filter((r) => r.isVisible);
-
-      if (realWinners.length > 1) {
-        throw new Error(
-          `Ambiguous Page State: Multiple outcomes detected: [${realWinners
-            .map((w) => w.outcome.name)
-            .join(', ')}]. Fix your locators!`
-        );
-      }
-
-      if (realWinners.length === 1) {
-        const winner = realWinners[0];
-        if (!winner) throw new Error('Winner vanished during processing');
-        
-        let payload: unknown | undefined = undefined;
-        if (winner.outcome.onOutcome && winner.locator) {
-          payload = await winner.outcome.onOutcome(winner.locator);
-        }
-        const resolution: AttemptResolution = {
-          isSuccess: winner.outcome.isSuccess,
-          outcome: winner.outcome.name,
-        };
-        if (payload !== undefined) resolution.payload = payload;
-        if (winner.locator != null) resolution.locator = winner.locator;
-        return resolution;
-      }
+  await new Promise<void>((resolve) => {
+    if (candidatePromises.length === 0) {
+      resolve();
+      return;
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    let resolvedCount = 0;
+    let bufferTimer: NodeJS.Timeout | null = null;
+
+    candidatePromises.forEach(p => {
+      p.then(winner => {
+        resolvedCount++;
+        if (winner) {
+          winners.push(winner);
+          if (!firstWinner) {
+            firstWinner = winner;
+            bufferTimer = setTimeout(() => resolve(), bufferMs);
+          }
+        }
+        
+        if (resolvedCount === candidatePromises.length) {
+          if (bufferTimer) clearTimeout(bufferTimer);
+          resolve();
+        }
+      });
+    });
+  });
+
+  if (winners.length > 1) {
+    throw new Error(
+      `Ambiguous Page State: Multiple outcomes detected: [${winners
+        .map((w) => w.outcome.name)
+        .join(', ')}]. Fix your locators!`
+    );
+  }
+
+  if (winners.length === 1) {
+    const winner = winners[0];
+    if (!winner) throw new Error('Winner vanished during processing');
+    
+    let payload: unknown | undefined = undefined;
+    if (winner.outcome.onOutcome && winner.locator) {
+      payload = await winner.outcome.onOutcome(winner.locator);
+    }
+    const resolution: AttemptResolution = {
+      isSuccess: winner.outcome.isSuccess,
+      outcome: winner.outcome.name,
+    };
+    if (payload !== undefined) resolution.payload = payload;
+    if (winner.locator != null) resolution.locator = winner.locator;
+    return resolution;
   }
 
   // Timeout Handling — no visible winner; do not run onOutcome (no winning locator).
@@ -180,10 +184,14 @@ ${errorMsg}
 export async function detectState(params: {
   outcomes: Outcome[];
   timeout?: number;
+  ambiguityBufferMs?: number;
 }) {
   return attemptAction(
     async () => {},
     params.outcomes,
-    { timeout: params.timeout ?? 5000 }
+    { 
+      timeout: params.timeout ?? 5000,
+      ...(params.ambiguityBufferMs !== undefined && { ambiguityBufferMs: params.ambiguityBufferMs })
+    }
   );
 }

--- a/src/clickToURL.ts
+++ b/src/clickToURL.ts
@@ -23,26 +23,41 @@ export async function clickToURL(
     }
 
     const attemptTimeout = Math.min(subTimeout, remaining);
+    const controller = new AbortController();
+    const { signal } = controller;
+    let globalTimerId: ReturnType<typeof setTimeout> | undefined;
 
     try {
       await Promise.race([
-        new Promise<never>((_, reject) => setTimeout(() => reject(new Error('Global timeout exceeded')), remaining)),
+        new Promise<never>((_, reject) => {
+          globalTimerId = setTimeout(() => {
+            controller.abort();
+            reject(new Error('__global_timeout__'));
+          }, remaining);
+        }),
         (async () => {
           await trigger.click({ timeout: attemptTimeout });
+          if (signal.aborted) return;
           await page.waitForURL(expectedUrl, { timeout: attemptTimeout, waitUntil: 'commit' });
         })(),
       ]);
+      clearTimeout(globalTimerId);
+      controller.abort(); // cancel any still-running inner branch
       return; // Success
     } catch (e) {
-      if (Date.now() - startTime > timeout) {
+      clearTimeout(globalTimerId);
+      const msg = e instanceof Error ? e.message : String(e);
+      const isGlobalTimeout = msg === '__global_timeout__' || signal.aborted;
+
+      if (isGlobalTimeout || Date.now() - startTime > timeout) {
         throw new Error(`clickToURL timed out after ${timeout}ms. Never navigated to expected URL.`);
       }
-      
+
       if (i === maxRetries) {
-        throw new Error(`clickToURL failed after ${maxRetries} retries. Error: ${e instanceof Error ? e.message : String(e)}`);
+        throw new Error(`clickToURL failed after ${maxRetries} retries. Error: ${msg}`);
       }
-      
-      console.log(`clickToURL: Navigation not detected after click (attempt ${i + 1}). Error: ${e instanceof Error ? e.message : String(e)}. Retrying in 100ms...`);
+
+      console.log(`clickToURL: Navigation not detected after click (attempt ${i + 1}). Error: ${msg}. Retrying in 100ms...`);
       await new Promise(resolve => setTimeout(resolve, 100));
     }
   }

--- a/src/director.test.ts
+++ b/src/director.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Director } from './director.js';
+import type { PlayResult } from './director.js';
+
+beforeAll(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'table').mockImplementation(() => {});
+});
+afterAll(() => { vi.restoreAllMocks(); });
+
+function makeDirector(collect = true) {
+  const director = new Director({ collect });
+  vi.spyOn(director as any, '_runPlay');
+  return director as any;
+}
+
+function stubRun(director: any, result: PlayResult) {
+  director._runPlay.mockResolvedValue(result);
+}
+
+function stubRunError(director: any, message: string) {
+  director._runPlay.mockRejectedValue(new Error(message));
+}
+
+const mockPlaybook = {
+  logScope: () => undefined,
+  runLabel: (name: string) => `MockPlaybook > ${name}`,
+  getPlay: vi.fn(),
+  buildCtx: vi.fn(),
+  withCtx: vi.fn(),
+  getPage: vi.fn(),
+  name: 'MockPlaybook',
+} as any;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'table').mockImplementation(() => {});
+});
+
+// ── assertCan — collect mode ──────────────────────────────────────────────────
+
+describe('assertCan — collect mode', () => {
+  it('does not throw when play fails', async () => {
+    const d = makeDirector();
+    stubRun(d, { isSuccess: false, outcome: 'blocked' });
+    await expect(d.assertCan(mockPlaybook, 'viewPage')).resolves.not.toThrow();
+  });
+
+  it('records a failure when play fails', async () => {
+    const d = makeDirector();
+    stubRun(d, { isSuccess: false, outcome: 'blocked' });
+    await d.assertCan(mockPlaybook, 'viewPage');
+    const collected = (d as any)._collected;
+    expect(collected).toHaveLength(1);
+    expect(collected[0]).toMatchObject({ play: 'viewPage', expected: 'success', outcome: 'blocked', pass: false });
+  });
+
+  it('records a pass when play succeeds', async () => {
+    const d = makeDirector();
+    stubRun(d, { isSuccess: true, outcome: 'success' });
+    await d.assertCan(mockPlaybook, 'viewPage');
+    const collected = (d as any)._collected;
+    expect(collected[0]).toMatchObject({ pass: true });
+  });
+
+  it('records a failure and does not throw when _runPlay throws', async () => {
+    const d = makeDirector();
+    stubRunError(d, 'Playwright timeout');
+    await expect(d.assertCan(mockPlaybook, 'viewPage')).resolves.not.toThrow();
+    expect((d as any)._collected[0]).toMatchObject({ pass: false, outcome: 'Playwright timeout' });
+  });
+});
+
+// ── assertCannot — collect mode ───────────────────────────────────────────────
+
+describe('assertCannot — collect mode', () => {
+  it('does not throw when play succeeds (unexpected success)', async () => {
+    const d = makeDirector();
+    stubRun(d, { isSuccess: true, outcome: 'success' });
+    await expect(d.assertCannot(mockPlaybook, 'deleteUser')).resolves.not.toThrow();
+  });
+
+  it('records a failure when play unexpectedly succeeds', async () => {
+    const d = makeDirector();
+    stubRun(d, { isSuccess: true, outcome: 'success' });
+    await d.assertCannot(mockPlaybook, 'deleteUser');
+    expect((d as any)._collected[0]).toMatchObject({ expected: 'failure', pass: false });
+  });
+
+  it('records a pass when play fails (expected block)', async () => {
+    const d = makeDirector();
+    stubRun(d, { isSuccess: false, outcome: 'blocked' });
+    await d.assertCannot(mockPlaybook, 'deleteUser');
+    expect((d as any)._collected[0]).toMatchObject({ expected: 'failure', pass: true });
+  });
+});
+
+// ── fail-fast mode (regression) ───────────────────────────────────────────────
+
+describe('fail-fast mode', () => {
+  it('assertCan throws immediately on failure', async () => {
+    const d = makeDirector(false);
+    stubRun(d, { isSuccess: false, outcome: 'blocked' });
+    await expect(d.assertCan(mockPlaybook, 'viewPage')).rejects.toThrow('assertCan');
+  });
+
+  it('assertCannot throws immediately on unexpected success', async () => {
+    const d = makeDirector(false);
+    stubRun(d, { isSuccess: true, outcome: 'success' });
+    await expect(d.assertCannot(mockPlaybook, 'deleteUser')).rejects.toThrow('assertCannot');
+  });
+});
+
+// ── review() ──────────────────────────────────────────────────────────────────
+
+describe('review()', () => {
+  it('does not throw when all checks passed', async () => {
+    const d = makeDirector();
+    stubRun(d, { isSuccess: true, outcome: 'success' });
+    await d.assertCan(mockPlaybook, 'viewPage');
+    await expect(d.review()).resolves.not.toThrow();
+  });
+
+  it('throws with a summary when checks failed', async () => {
+    const d = makeDirector();
+    stubRun(d, { isSuccess: false, outcome: 'blocked' });
+    await d.assertCan(mockPlaybook, 'viewPage');
+    await expect(d.review()).rejects.toThrow('1 of 1 checks failed');
+  });
+
+  it('includes each failed play in the error message', async () => {
+    const d = makeDirector();
+    stubRun(d, { isSuccess: false, outcome: 'blocked' });
+    await d.assertCan(mockPlaybook, 'viewPage');
+    await d.assertCan(mockPlaybook, 'editPage');
+    await expect(d.review()).rejects.toThrow('2 of 2 checks failed');
+  });
+
+  it('is a no-op when no checks were collected', async () => {
+    const d = makeDirector();
+    await expect(d.review()).resolves.not.toThrow();
+  });
+
+  it('logs a table of results', async () => {
+    const d = makeDirector();
+    stubRun(d, { isSuccess: true, outcome: 'success' });
+    await d.assertCan(mockPlaybook, 'viewPage');
+    await d.review();
+    expect(console.table).toHaveBeenCalledOnce();
+  });
+});

--- a/src/director.test.ts
+++ b/src/director.test.ts
@@ -34,8 +34,6 @@ const mockPlaybook = {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.spyOn(console, 'log').mockImplementation(() => {});
-  vi.spyOn(console, 'table').mockImplementation(() => {});
 });
 
 // ── assertCan — collect mode ──────────────────────────────────────────────────
@@ -93,6 +91,13 @@ describe('assertCannot — collect mode', () => {
     stubRun(d, { isSuccess: false, outcome: 'blocked' });
     await d.assertCannot(mockPlaybook, 'deleteUser');
     expect((d as any)._collected[0]).toMatchObject({ expected: 'failure', pass: true });
+  });
+
+  it('records a failure and does not throw when _runPlay throws', async () => {
+    const d = makeDirector();
+    stubRunError(d, 'Playwright timeout');
+    await expect(d.assertCannot(mockPlaybook, 'deleteUser')).resolves.not.toThrow();
+    expect((d as any)._collected[0]).toMatchObject({ expected: 'failure', pass: false, outcome: 'Playwright timeout' });
   });
 });
 

--- a/src/director.ts
+++ b/src/director.ts
@@ -170,10 +170,25 @@ export class Director {
           })();
       
       console.log(`  ↻ Syncing ${targetPlaybook.runLabel('exists')}`);
-      const syncResult = await this._runPlay(targetPlaybook, 'exists', params, { 
+      let syncResult = await this._runPlay(targetPlaybook, 'exists', params, { 
         indent: 1, 
         labelSuffix: '(sync check)' 
       });
+
+      // Under the hood: if shouldReloadSync is true, automatically retry up to 2 times
+      let syncAttempts = 0;
+      while (!syncResult.isSuccess && shouldReload && syncAttempts < 2) {
+        if (targetPage) {
+          const startT = Date.now();
+          await targetPage.reload({ waitUntil: 'domcontentloaded' });
+          console.log(`    ↻  page reloaded  (${Date.now() - startT}ms)`);
+        }
+        syncResult = await this._runPlay(targetPlaybook, 'exists', params, {
+          indent: 1,
+          labelSuffix: `(sync check attempt ${syncAttempts + 2})`,
+        });
+        syncAttempts++;
+      }
 
       if (!syncResult.isSuccess) {
         throw new Error(

--- a/src/director.ts
+++ b/src/director.ts
@@ -120,7 +120,12 @@ export class Director {
     }
 
     if (!existsResult.isSuccess) {
-      await this._runPlay(playbook, 'create', params, { indent: 1 });
+      const createResult = await this._runPlay(playbook, 'create', params, { indent: 1 });
+      if (!createResult.isSuccess) {
+        throw new Error(
+          `[${playbook.runLabel('create')}] ensureExists: create play did not succeed (outcome: "${createResult.outcome}")`
+        );
+      }
     }
 
     if (opts?.syncTo) {

--- a/src/director.ts
+++ b/src/director.ts
@@ -7,11 +7,19 @@ export type RecheckStrategy = {
 };
 
 export type DirectorConfig = {
+  collect?: boolean;
   ensureExists?: {
     recheckBeforeCreate?: RecheckStrategy;
     shouldReloadSync?: boolean; // Default behavior when syncTo is provided
   };
   ambiguityBufferMs?: number;
+};
+
+type CollectedResult = {
+  play: string;
+  expected: 'success' | 'failure';
+  outcome: string;
+  pass: boolean;
 };
 
 export type EnsureExistsOptions = {
@@ -30,7 +38,12 @@ export type PlayResult = {
 
 
 export class Director {
-  constructor(private config?: DirectorConfig) {}
+  private readonly _mode: 'fail-fast' | 'collect';
+  private readonly _collected: CollectedResult[] = [];
+
+  constructor(private config?: DirectorConfig) {
+    this._mode = config?.collect ? 'collect' : 'fail-fast';
+  }
 
   /**
    * Runs a play and asserts that it resulted in a **success** outcome.
@@ -44,6 +57,22 @@ export class Director {
     const params = args[0] as unknown;
     const scopeStr = playbook.logScope() ? ` ${playbook.logScope()}` : '';
     console.log(`Assert:${scopeStr} can ${playName} ${playbook.name}`);
+
+    if (this._mode === 'collect') {
+      let result: PlayResult;
+      try {
+        result = await this._runPlay(playbook, playName, params, { indent: 1 });
+      } catch (e) {
+        const outcome = e instanceof Error ? e.message : String(e);
+        this._collected.push({ play: playName, expected: 'success', outcome, pass: false });
+        console.log('');
+        return { isSuccess: false, outcome };
+      }
+      this._collected.push({ play: playName, expected: 'success', outcome: result.outcome, pass: result.isSuccess });
+      console.log('');
+      return result;
+    }
+
     const result = await this._runPlay(playbook, playName, params, { indent: 1 });
     console.log('');
     if (!result.isSuccess) {
@@ -66,6 +95,22 @@ export class Director {
     const params = args[0] as unknown;
     const scopeStr = playbook.logScope() ? ` ${playbook.logScope()}` : '';
     console.log(`Assert:${scopeStr} cannot ${playName} ${playbook.name}`);
+
+    if (this._mode === 'collect') {
+      let result: PlayResult;
+      try {
+        result = await this._runPlay(playbook, playName, params, { indent: 1 });
+      } catch (e) {
+        const outcome = e instanceof Error ? e.message : String(e);
+        this._collected.push({ play: playName, expected: 'failure', outcome, pass: false });
+        console.log('');
+        return { isSuccess: false, outcome };
+      }
+      this._collected.push({ play: playName, expected: 'failure', outcome: result.outcome, pass: !result.isSuccess });
+      console.log('');
+      return result;
+    }
+
     const result = await this._runPlay(playbook, playName, params, { indent: 1 });
     console.log('');
     if (result.isSuccess) {
@@ -74,6 +119,31 @@ export class Director {
       );
     }
     return result;
+  }
+
+  /**
+   * In collect mode: logs a results table and throws if any checks failed.
+   * No-op in fail-fast mode (errors already threw at the call site).
+   */
+  async review(): Promise<void> {
+    if (this._collected.length === 0) return;
+
+    console.table(
+      this._collected.map(r => ({
+        Play: r.play,
+        Expected: r.expected,
+        Outcome: r.outcome,
+        Status: r.pass ? '✅ PASS' : '❌ FAIL',
+      }))
+    );
+
+    const failures = this._collected.filter(r => !r.pass);
+    if (failures.length === 0) return;
+
+    const lines = failures
+      .map(r => `  ❌ ${r.play} — expected ${r.expected}, got "${r.outcome}"`)
+      .join('\n');
+    throw new Error(`Director.review(): ${failures.length} of ${this._collected.length} checks failed\n\n${lines}`);
   }
 
   /**

--- a/src/director.ts
+++ b/src/director.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test';
-import type { Playbook } from './playbook.js';
+import type { Playbook, PlaybookPlays } from './playbook.js';
+import type { RunOptions } from './play.js';
 export type RecheckStrategy = {
   maxRetries: number;
   shouldReload?: boolean; // If true, reloads the page before retrying
@@ -10,6 +11,7 @@ export type DirectorConfig = {
     recheckBeforeCreate?: RecheckStrategy;
     shouldReloadSync?: boolean; // Default behavior when syncTo is provided
   };
+  ambiguityBufferMs?: number;
 };
 
 export type EnsureExistsOptions = {
@@ -34,11 +36,12 @@ export class Director {
    * Runs a play and asserts that it resulted in a **success** outcome.
    * Throws if the play produced no detect/attempt outcome or a failure outcome.
    */
-  async assertCan(
-    playbook: Playbook,
-    playName: string,
-    params: unknown
+  async assertCan<P extends PlaybookPlays, K extends Extract<keyof P, string>>(
+    playbook: Playbook<P>,
+    playName: K,
+    ...args: Parameters<P[K]> extends [infer Param] ? [Param] : []
   ): Promise<PlayResult> {
+    const params = args[0] as unknown;
     const scopeStr = playbook.logScope() ? ` ${playbook.logScope()}` : '';
     console.log(`Assert:${scopeStr} can ${playName} ${playbook.name}`);
     const result = await this._runPlay(playbook, playName, params, { indent: 1 });
@@ -55,11 +58,12 @@ export class Director {
    * Runs a play and asserts that it resulted in a **failure** outcome.
    * Throws if the play produced a success outcome.
    */
-  async assertCannot(
-    playbook: Playbook,
-    playName: string,
-    params: unknown
+  async assertCannot<P extends PlaybookPlays, K extends Extract<keyof P, string>>(
+    playbook: Playbook<P>,
+    playName: K,
+    ...args: Parameters<P[K]> extends [infer Param] ? [Param] : []
   ): Promise<PlayResult> {
+    const params = args[0] as unknown;
     const scopeStr = playbook.logScope() ? ` ${playbook.logScope()}` : '';
     console.log(`Assert:${scopeStr} cannot ${playName} ${playbook.name}`);
     const result = await this._runPlay(playbook, playName, params, { indent: 1 });
@@ -76,7 +80,12 @@ export class Director {
    * Runs a play and returns the outcome without asserting.
    * Use with `assertCan` / `assertCannot` when you need to aggregate results (e.g. permission matrices).
    */
-  async run(playbook: Playbook, playName: string, params: unknown): Promise<PlayResult> {
+  async run<P extends PlaybookPlays, K extends Extract<keyof P, string>>(
+    playbook: Playbook<P>,
+    playName: K,
+    ...args: Parameters<P[K]> extends [infer Param] ? [Param] : []
+  ): Promise<PlayResult> {
+    const params = args[0] as unknown;
     const scopeStr = playbook.logScope() ? ` ${playbook.logScope()}` : '';
     console.log(`Run:${scopeStr} ${playName} ${playbook.name}`);
     const result = await this._runPlay(playbook, playName, params, { indent: 1 });
@@ -92,11 +101,23 @@ export class Director {
    *
    * Requires the Playbook to have `exists` and `create` plays.
    */
-  async ensureExists(
-    playbook: Playbook,
-    params: unknown,
-    opts?: EnsureExistsOptions
+  async ensureExists<P extends PlaybookPlays>(
+    playbook: Playbook<P>,
+    ...args: Parameters<P['exists']> extends [infer Param] ? [Param, EnsureExistsOptions?] : [EnsureExistsOptions?]
   ): Promise<void> {
+    const isOptions = (arg: unknown): arg is EnsureExistsOptions => 
+      arg !== null && typeof arg === 'object' && ('syncTo' in arg || 'shouldReloadSync' in arg || 'recheckBeforeCreate' in arg);
+    
+    let params: unknown = undefined;
+    let opts: EnsureExistsOptions | undefined = undefined;
+
+    if (args.length === 1) {
+      if (isOptions(args[0])) opts = args[0];
+      else params = args[0];
+    } else if (args.length === 2) {
+      params = args[0];
+      opts = args[1] as EnsureExistsOptions;
+    }
     const scopeStr = playbook.logScope() ? ` ${playbook.logScope()}` : '';
     console.log(`Ensure:${scopeStr} ${playbook.name} exists`);
 
@@ -177,7 +198,11 @@ export class Director {
     const ctx = playbook.buildCtx();
     const label = playbook.runLabel(playName);
 
-    const { lastOutcome } = await play.run(label, ctx, opts);
+    const runOpts: RunOptions = { ...opts };
+    if (this.config?.ambiguityBufferMs !== undefined) {
+      runOpts.ambiguityBufferMs = this.config.ambiguityBufferMs;
+    }
+    const { lastOutcome } = await play.run(label, ctx, runOpts);
 
     if (lastOutcome) {
       const r: PlayResult = {

--- a/src/outcomes.ts
+++ b/src/outcomes.ts
@@ -3,8 +3,8 @@ import type { Outcome } from './attemptAction.js';
 
 /**
  * An outcome as configured by the user — `locator` may be a page-bound function
- * resolved by Play before calling attemptAction. `after` is consumed by Play
- * to derive the `timeout` parameter.
+ * resolved by Play before calling attemptAction. `timeout` is passed directly
+ * as `AttemptActionOptions.timeout` to `attemptAction`; there is no `after` field.
  */
 export type OutcomeSpec = Omit<Outcome, 'locator'> & {
   locator?: Locator | ((page: Page, ctx: Record<string, unknown>) => Locator | Promise<Locator>);

--- a/src/play.test.ts
+++ b/src/play.test.ts
@@ -347,7 +347,7 @@ describe('error labels', () => {
     const play = new Play().attempt('submit', async () => {}, [Outcomes.success(mockLocator)]);
 
     await expect(play.run('Pb > play', { page }))
-      .rejects.toThrow('[Pb > play > submit]');
+      .rejects.toThrow('[Pb > play > attempt: submit]');
   });
 });
 

--- a/src/play.ts
+++ b/src/play.ts
@@ -46,6 +46,8 @@ export type DetectCandidate = {
   name: string;
   isSuccess: boolean;
   locator?: Locator | AsyncLocatorFn;
+  isTimeoutOutcome?: boolean;
+  isActionErrorOutcome?: boolean;
   /**
    * When this branch wins, called with the winning locator; return value becomes the next act’s
    * third-argument `outcome.payload` (see {@link PlayOutcome}).
@@ -274,6 +276,8 @@ export class Play {
               name: c.name,
               isSuccess: c.isSuccess,
               ...(c.locator !== undefined && { locator: c.locator }),
+              ...(c.isTimeoutOutcome !== undefined && { isTimeoutOutcome: c.isTimeoutOutcome }),
+              ...(c.isActionErrorOutcome !== undefined && { isActionErrorOutcome: c.isActionErrorOutcome }),
               ...(c.onOutcome !== undefined && { onOutcome: c.onOutcome }),
             }));
             const detectParams: Parameters<typeof detectState>[0] = { outcomes };

--- a/src/play.ts
+++ b/src/play.ts
@@ -19,11 +19,13 @@ export type ActOptions = {
 
 export type DetectOptions = ActOptions & {
   timeout?: number;
+  ambiguityBufferMs?: number;
 };
 
 export type RunOptions = {
   indent?: number;
   labelSuffix?: string;
+  ambiguityBufferMs?: number;
 };
 
 /** One branch returned from the `.detect()` callback — forwarded to `detectState` / `attemptAction`. */
@@ -78,7 +80,7 @@ export type ActFn = (page: Page, ctx: PlayCtx, outcome: PlayOutcome | undefined)
 
 type ActRecord =
   | { kind: 'act'; name: string; fn: ActFn; skip?: ActOptions['skip'] }
-  | { kind: 'detect'; fn: (page: Page) => DetectCandidate[]; timeout?: number; skip?: ActOptions['skip'] }
+  | { kind: 'detect'; fn: (page: Page) => DetectCandidate[]; timeout?: number; ambiguityBufferMs?: number; skip?: ActOptions['skip'] }
   | {
       kind: 'attempt';
       name: string;
@@ -125,6 +127,7 @@ export class Play {
       kind: 'detect',
       fn,
       ...(opts.timeout !== undefined && { timeout: opts.timeout }),
+      ...(opts.ambiguityBufferMs !== undefined && { ambiguityBufferMs: opts.ambiguityBufferMs }),
       skip: opts.skip,
     });
   }
@@ -239,6 +242,8 @@ export class Play {
             }));
             const detectParams: Parameters<typeof detectState>[0] = { outcomes };
             if (act.timeout !== undefined) detectParams.timeout = act.timeout;
+            if (act.ambiguityBufferMs !== undefined) detectParams.ambiguityBufferMs = act.ambiguityBufferMs;
+            else if (opts?.ambiguityBufferMs !== undefined) detectParams.ambiguityBufferMs = opts.ambiguityBufferMs;
             const detectResult = await detectState(detectParams);
             lastOutcome = outcomeFromResolution(detectResult);
             console.log(`${aPrefix}✅ ${actName}  (${Date.now() - t}ms) → outcome: ${lastOutcome.name}`);
@@ -258,7 +263,10 @@ export class Play {
               }),
             })));
 
-            const attemptOpts = act.opts;
+            const attemptOpts = { ...act.opts };
+            if (attemptOpts.ambiguityBufferMs === undefined && opts?.ambiguityBufferMs !== undefined) {
+              attemptOpts.ambiguityBufferMs = opts.ambiguityBufferMs;
+            }
 
             const incoming = lastOutcome;
             const result = await attemptAction(

--- a/src/play.ts
+++ b/src/play.ts
@@ -11,6 +11,19 @@ import type { OutcomeSpec } from './outcomes.js';
 
 export type { AttemptActionOptions } from './attemptAction.js';
 
+/**
+ * Helper to explicitly attach a name to a function for automatic logging when
+ * using the single-argument versions of .nav(), .prep(), .cleanup(), or .attempt().
+ */
+export function namedAct<T extends Function>(name: string, fn: T): T {
+  Object.defineProperty(fn, 'actName', { value: name, enumerable: false, writable: false });
+  return fn;
+}
+
+function _getFnName(fn: Function): string | undefined {
+  return (fn as any).actName || (fn.name && fn.name !== 'anonymous' && fn.name !== '' ? fn.name : undefined);
+}
+
 // ── Public types ──────────────────────────────────────────────────────────────
 
 export type ActOptions = {
@@ -113,8 +126,9 @@ export class Play {
   nav(fn: ActFn, opts?: ActOptions): Play;
   nav(name: string, fn: ActFn, opts?: ActOptions): Play;
   nav(nameOrFn: string | ActFn, fnOrOpts?: ActFn | ActOptions, maybeOpts?: ActOptions): Play {
-    const name = typeof nameOrFn === 'string' ? `nav: ${nameOrFn}` : 'nav';
     const fn = (typeof nameOrFn === 'string' ? fnOrOpts : nameOrFn) as ActFn;
+    const providedName = typeof nameOrFn === 'string' ? nameOrFn : _getFnName(fn);
+    const name = providedName ? `nav: ${providedName}` : 'nav';
     const opts = ((typeof nameOrFn === 'string' ? maybeOpts : fnOrOpts) || {}) as ActOptions;
     return this._append({ kind: 'act', name, fn, skip: opts.skip });
   }
@@ -122,8 +136,9 @@ export class Play {
   prep(fn: ActFn, opts?: ActOptions): Play;
   prep(name: string, fn: ActFn, opts?: ActOptions): Play;
   prep(nameOrFn: string | ActFn, fnOrOpts?: ActFn | ActOptions, maybeOpts?: ActOptions): Play {
-    const name = typeof nameOrFn === 'string' ? `prep: ${nameOrFn}` : 'prep';
     const fn = (typeof nameOrFn === 'string' ? fnOrOpts : nameOrFn) as ActFn;
+    const providedName = typeof nameOrFn === 'string' ? nameOrFn : _getFnName(fn);
+    const name = providedName ? `prep: ${providedName}` : 'prep';
     const opts = ((typeof nameOrFn === 'string' ? maybeOpts : fnOrOpts) || {}) as ActOptions;
     return this._append({ kind: 'act', name, fn, skip: opts.skip });
   }
@@ -167,10 +182,11 @@ export class Play {
     const action = nameOrAction as ActFn;
     const outcomes = actionOrOutcomes as OutcomeSpec[];
     const opts = outcomesOrOpts as AttemptActionOptions | undefined;
+    const actionName = _getFnName(action);
 
     return this._append({
       kind: 'attempt',
-      name: 'attempt',
+      name: actionName || 'attempt',
       action,
       outcomes,
       ...(opts !== undefined && { opts }),
@@ -181,10 +197,11 @@ export class Play {
   cleanup(name: string, fn: ActFn, opts?: ActOptions): Play;
   cleanup(nameOrFn: string | ActFn, fnOrOpts?: ActFn | ActOptions, maybeOpts?: ActOptions): Play {
     const fn = (typeof nameOrFn === 'string' ? fnOrOpts : nameOrFn) as ActFn;
+    const name = typeof nameOrFn === 'string' ? nameOrFn : _getFnName(fn);
     const opts = ((typeof nameOrFn === 'string' ? maybeOpts : fnOrOpts) || {}) as ActOptions;
     return this._append({ 
       kind: 'cleanup', 
-      ...(typeof nameOrFn === 'string' && { name: nameOrFn }), 
+      ...(name !== undefined && { name }), 
       fn, 
       skip: opts.skip 
     });

--- a/src/play.ts
+++ b/src/play.ts
@@ -195,6 +195,9 @@ export class Play {
       let shouldSkip = false;
       if (runError) {
         shouldSkip = true;
+      } else if (lastOutcome && !lastOutcome.isSuccess) {
+        // Short-circuit: if a detect resolved to a failure state, skip subsequent acts
+        shouldSkip = true;
       } else if (act.kind !== 'attempt' && act.skip !== undefined) {
         try {
           shouldSkip = typeof act.skip === 'function' ? act.skip(ctx, lastOutcome) : act.skip;

--- a/src/play.ts
+++ b/src/play.ts
@@ -340,7 +340,7 @@ export class Play {
 
         let shouldSkipCleanup: boolean | undefined;
         try {
-          shouldSkipCleanup = typeof act.skip === 'function' ? await act.skip(ctx, lastOutcome) : act.skip;
+          shouldSkipCleanup = typeof act.skip === 'function' ? act.skip(ctx, lastOutcome) : act.skip;
         } catch (err: unknown) {
           const raw = err instanceof Error ? err : new Error(String(err));
           const wrapped = new Error(`[${label} > cleanup] skip predicate threw: ${raw.message}`, { cause: raw });

--- a/src/play.ts
+++ b/src/play.ts
@@ -88,7 +88,7 @@ type ActRecord =
       outcomes: OutcomeSpec[];
       opts?: AttemptActionOptions;
     }
-  | { kind: 'cleanup'; fn: ActFn; skip?: ActOptions['skip'] }
+  | { kind: 'cleanup'; name?: string; fn: ActFn; skip?: ActOptions['skip'] }
   | { kind: 'reload'; opts: Parameters<Page['reload']>[0] | undefined; skip?: ActOptions['skip'] };
 
 // ── Play ──────────────────────────────────────────────────────────────────────
@@ -110,12 +110,22 @@ export class Play {
     return this._append({ kind: 'act', name, fn, skip: opts.skip });
   }
 
-  nav(fn: ActFn, opts: ActOptions = {}): Play {
-    return this._append({ kind: 'act', name: 'nav', fn, skip: opts.skip });
+  nav(fn: ActFn, opts?: ActOptions): Play;
+  nav(name: string, fn: ActFn, opts?: ActOptions): Play;
+  nav(nameOrFn: string | ActFn, fnOrOpts?: ActFn | ActOptions, maybeOpts?: ActOptions): Play {
+    const name = typeof nameOrFn === 'string' ? `nav: ${nameOrFn}` : 'nav';
+    const fn = (typeof nameOrFn === 'string' ? fnOrOpts : nameOrFn) as ActFn;
+    const opts = ((typeof nameOrFn === 'string' ? maybeOpts : fnOrOpts) || {}) as ActOptions;
+    return this._append({ kind: 'act', name, fn, skip: opts.skip });
   }
 
-  prep(fn: ActFn, opts: ActOptions = {}): Play {
-    return this._append({ kind: 'act', name: 'prep', fn, skip: opts.skip });
+  prep(fn: ActFn, opts?: ActOptions): Play;
+  prep(name: string, fn: ActFn, opts?: ActOptions): Play;
+  prep(nameOrFn: string | ActFn, fnOrOpts?: ActFn | ActOptions, maybeOpts?: ActOptions): Play {
+    const name = typeof nameOrFn === 'string' ? `prep: ${nameOrFn}` : 'prep';
+    const fn = (typeof nameOrFn === 'string' ? fnOrOpts : nameOrFn) as ActFn;
+    const opts = ((typeof nameOrFn === 'string' ? maybeOpts : fnOrOpts) || {}) as ActOptions;
+    return this._append({ kind: 'act', name, fn, skip: opts.skip });
   }
 
   reload(reloadOpts?: Parameters<Page['reload']>[0], opts: ActOptions = {}): Play {
@@ -167,8 +177,17 @@ export class Play {
     });
   }
 
-  cleanup(fn: ActFn, opts: ActOptions = {}): Play {
-    return this._append({ kind: 'cleanup', fn, skip: opts.skip });
+  cleanup(fn: ActFn, opts?: ActOptions): Play;
+  cleanup(name: string, fn: ActFn, opts?: ActOptions): Play;
+  cleanup(nameOrFn: string | ActFn, fnOrOpts?: ActFn | ActOptions, maybeOpts?: ActOptions): Play {
+    const fn = (typeof nameOrFn === 'string' ? fnOrOpts : nameOrFn) as ActFn;
+    const opts = ((typeof nameOrFn === 'string' ? maybeOpts : fnOrOpts) || {}) as ActOptions;
+    return this._append({ 
+      kind: 'cleanup', 
+      ...(typeof nameOrFn === 'string' && { name: nameOrFn }), 
+      fn, 
+      skip: opts.skip 
+    });
   }
 
   // ── Execution ────────────────────────────────────────────────────────────────
@@ -346,9 +365,9 @@ function _actLabel(act: ActRecord): string {
     case 'detect':
       return 'detect';
     case 'attempt':
-      return act.name;
+      return act.name === 'attempt' ? 'attempt' : `attempt: ${act.name}`;
     case 'cleanup':
-      return 'cleanup';
+      return act.name ? `cleanup: ${act.name}` : 'cleanup';
     case 'reload':
       return 'reload';
   }

--- a/src/play.ts
+++ b/src/play.ts
@@ -196,7 +196,15 @@ export class Play {
       if (runError) {
         shouldSkip = true;
       } else if (act.kind !== 'attempt' && act.skip !== undefined) {
-        shouldSkip = typeof act.skip === 'function' ? act.skip(ctx, lastOutcome) : act.skip;
+        try {
+          shouldSkip = typeof act.skip === 'function' ? act.skip(ctx, lastOutcome) : act.skip;
+        } catch (err: unknown) {
+          const raw = err instanceof Error ? err : new Error(String(err));
+          const wrapped = new Error(`[${label} > ${actName}] skip predicate threw: ${raw.message}`, { cause: raw });
+          console.log(`${aPrefix}❌ ${actName}  skip predicate threw → ${wrapped.message}`);
+          runError = wrapped;
+          shouldSkip = true;
+        }
       }
 
       if (shouldSkip) {
@@ -279,7 +287,16 @@ export class Play {
       for (const act of cleanupActs) {
         if (act.kind !== 'cleanup') continue;
 
-        const shouldSkipCleanup = typeof act.skip === 'function' ? await act.skip(ctx, lastOutcome) : act.skip;
+        let shouldSkipCleanup: boolean | undefined;
+        try {
+          shouldSkipCleanup = typeof act.skip === 'function' ? await act.skip(ctx, lastOutcome) : act.skip;
+        } catch (err: unknown) {
+          const raw = err instanceof Error ? err : new Error(String(err));
+          const wrapped = new Error(`[${label} > cleanup] skip predicate threw: ${raw.message}`, { cause: raw });
+          console.log(`${aPrefix}❌ cleanup  skip predicate threw → ${wrapped.message}`);
+          if (!runError) runError = wrapped;
+          continue;
+        }
         if (shouldSkipCleanup) {
           console.log(`${aPrefix}⏭  cleanup  SKIPPED`);
           continue;

--- a/tests/director.spec.ts
+++ b/tests/director.spec.ts
@@ -68,7 +68,7 @@ const datasetPb = new Playbook('DatasetPlaybook', {
         await page.getByRole('menuitem', { name: 'Rename' }).click();
         await page.getByRole('textbox').fill(name);
         await page.getByRole('button', { name: 'Save' }).click();
-        await page.getByText('Updated dataset').first().waitFor();
+        await page.locator('li[data-sonner-toast]').filter({ hasText: 'Updated dataset' }).last().waitFor();
       } else {
         await page.keyboard.press('Escape');
       }


### PR DESCRIPTION
WIP: Added automatic retry for ensureExists sync check, fixed delete timeouts, added poc test runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conditional step skipping now supports runtime predicates using prior outcomes.
  * Director can collect assertions for aggregated review and reporting; new review workflow added.
  * Named acts added for clearer labels and error messages.

* **Bug Fixes**
  * Improved ambiguity detection with configurable settling/buffer time to reduce false positives.
  * More robust navigation retry timeout handling.
  * Stronger validation around resource-creation and post-sync existence checks.

* **Docs**
  * Roadmap and API docs updated; minor UI docs adjusted for nullable outcome values.

* **Tests / Chores**
  * Added Director tests; added a PoC npm script.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-sugar/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->