### PR TITLE
feat: extract cross-pollination helpers from playwright-smart-table

### DIFF
--- a/src/elementTracker.ts
+++ b/src/elementTracker.ts
@@ -1,0 +1,66 @@
+import type { Locator, Page } from '@playwright/test';
+
+/**
+ * Tracks which DOM elements have already been processed, using a browser-side WeakMap.
+ * Works for both append-only DOMs (identity match) and virtualized/recycled DOMs
+ * (text-content signature match).
+ *
+ * Typical use: loop over a virtualized list, call `getUnseenIndices` each page-turn,
+ * and only process rows that haven't been seen before.
+ */
+export class ElementTracker {
+  public readonly id: string;
+
+  constructor(prefix = 'tracker') {
+    this.id = `__pwSugar_${prefix}_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+  }
+
+  /**
+   * Returns indices of elements whose text content has changed since the last commit
+   * (or all indices on first call). Does NOT persist — use `commitIndices` to save.
+   */
+  async peekUnseenIndices(locators: Locator): Promise<number[]> {
+    return locators.evaluateAll((elements, trackerId) => {
+      const win = window as unknown as Record<string, unknown>;
+      if (!win[trackerId]) win[trackerId] = new WeakMap<Element, string>();
+      const seen = win[trackerId] as WeakMap<Element, string>;
+      const result: number[] = [];
+      elements.forEach((el, i) => {
+        if (seen.get(el) !== el.textContent) result.push(i);
+      });
+      return result;
+    }, this.id);
+  }
+
+  /**
+   * Marks `indices` as seen (persists their current text content in the browser WeakMap).
+   * Only call this for rows you actually intend to process.
+   */
+  async commitIndices(locators: Locator, indices: number[]): Promise<void> {
+    await locators.evaluateAll((elements, [trackerId, idxs]) => {
+      const win = window as unknown as Record<string, unknown>;
+      if (!win[trackerId]) win[trackerId] = new WeakMap<Element, string>();
+      const seen = win[trackerId] as WeakMap<Element, string>;
+      for (const i of idxs) {
+        const el = elements[i];
+        if (el) seen.set(el, el.textContent ?? '');
+      }
+    }, [this.id, indices] as [string, number[]]);
+  }
+
+  /** Peeks at unseen indices and immediately commits them. */
+  async getUnseenIndices(locators: Locator): Promise<number[]> {
+    const indices = await this.peekUnseenIndices(locators);
+    await this.commitIndices(locators, indices);
+    return indices;
+  }
+
+  /** Removes the tracking WeakMap from the browser window. Call when done. */
+  async cleanup(page: Page): Promise<void> {
+    try {
+      await page.evaluate((id: string) => { delete (window as unknown as Record<string, unknown>)[id]; }, this.id);
+    } catch {
+      // ignore context-destroyed errors
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,3 +14,7 @@ export * from './hoverMenu.js';
 export * from './strategies.js';
 
 export * from './watchFor.js';
+export * from './waitForCondition.js';
+export * from './elementTracker.js';
+export * from './stringUtils.js';
+export * from './stabilization.js';

--- a/src/stabilization.ts
+++ b/src/stabilization.ts
@@ -1,0 +1,102 @@
+import type { Locator, Page } from '@playwright/test';
+
+/**
+ * A StabilizationStrategy wraps an async action and returns `true` when the DOM
+ * has settled in the expected way, or `false` on timeout.
+ *
+ * @param rows - Locator for the repeating items to observe (table rows, list items, etc.)
+ * @param page - Playwright Page (for `waitForTimeout` polling)
+ * @param action - The interaction to perform (click, scroll, etc.)
+ */
+export type StabilizationStrategy = (
+  rows: Locator,
+  page: Page,
+  action: () => Promise<void>,
+) => Promise<boolean>;
+
+export const StabilizationStrategies = {
+  /**
+   * Waits for the visible text of the observed rows to change.
+   *
+   * @param options.scope `'all'` compares all rows; `'first'` only compares the first row
+   *   (faster for large lists where only the first row changing signals a page turn).
+   * @param options.timeout Poll window in ms (default 5000).
+   */
+  contentChanged(options: { scope?: 'all' | 'first'; timeout?: number } = {}): StabilizationStrategy {
+    return async (rows, page, action) => {
+      const { scope = 'all', timeout = 5000 } = options;
+      const getFingerprint = () =>
+        scope === 'first'
+          ? rows.first().innerText().catch(() => '')
+          : rows.allInnerTexts().then(t => t.join('|'));
+
+      const before = await getFingerprint();
+      await action();
+
+      const deadline = Date.now() + timeout;
+      while (Date.now() < deadline) {
+        if ((await getFingerprint()) !== before) return true;
+        await page.waitForTimeout(100);
+      }
+      return false;
+    };
+  },
+
+  /**
+   * Waits for the row count to strictly increase — best for append-only / infinite-scroll lists.
+   *
+   * @param options.timeout Poll window in ms (default 5000).
+   */
+  rowCountIncreased(options: { timeout?: number } = {}): StabilizationStrategy {
+    return async (rows, page, action) => {
+      const { timeout = 5000 } = options;
+      const before = await rows.count();
+      await action();
+
+      const deadline = Date.now() + timeout;
+      while (Date.now() < deadline) {
+        if ((await rows.count()) > before) return true;
+        await page.waitForTimeout(100);
+      }
+      return false;
+    };
+  },
+
+  /**
+   * Waits for a spinner/overlay to disappear after the action.
+   * Falls back to a 500 ms pause when no `spinnerSelector` is given.
+   *
+   * @param options.spinnerSelector CSS selector for the loading indicator.
+   * @param options.timeout Timeout for waiting the spinner to detach (default 5000).
+   */
+  networkIdle(options: { spinnerSelector?: string; timeout?: number } = {}): StabilizationStrategy {
+    return async (rows, page, action) => {
+      const { timeout = 5000 } = options;
+
+      if (options.spinnerSelector) {
+        const spinner = rows.page().locator(options.spinnerSelector).first();
+        const existedBefore = (await spinner.count()) > 0;
+        await action();
+
+        if (!existedBefore) {
+          const appearDeadline = Date.now() + 500;
+          while (Date.now() < appearDeadline && (await spinner.count()) === 0) {
+            await page.waitForTimeout(50);
+          }
+          if ((await spinner.count()) === 0) return true;
+        }
+
+        try {
+          await spinner.waitFor({ state: 'detached', timeout });
+          return true;
+        } catch {
+          return false;
+        }
+      }
+
+      await action();
+      await page.waitForTimeout(500);
+      return true;
+    };
+  },
+};

--- a/src/stringUtils.ts
+++ b/src/stringUtils.ts
@@ -1,0 +1,45 @@
+/**
+ * Levenshtein distance with case-insensitive weighting (case-only differences cost 0.1).
+ */
+export function levenshteinDistance(a: string, b: string): number {
+  const matrix: number[][] = Array.from({ length: b.length + 1 }, (_, i) => [i]);
+  for (let j = 0; j <= a.length; j++) matrix[0]![j] = j;
+
+  for (let i = 1; i <= b.length; i++) {
+    for (let j = 1; j <= a.length; j++) {
+      if (b[i - 1] === a[j - 1]) {
+        matrix[i]![j] = matrix[i - 1]![j - 1]!;
+      } else {
+        const cost = b[i - 1]!.toLowerCase() === a[j - 1]!.toLowerCase() ? 0.1 : 1;
+        matrix[i]![j] = Math.min(
+          matrix[i - 1]![j - 1]! + cost,
+          matrix[i]![j - 1]! + 1,
+          matrix[i - 1]![j]! + 1,
+        );
+      }
+    }
+  }
+  return matrix[b.length]![a.length]!;
+}
+
+/** Similarity score between 0 (different) and 1 (identical). */
+export function stringSimilarity(a: string, b: string): number {
+  const maxLen = Math.max(a.length, b.length);
+  return maxLen === 0 ? 1 : 1 - levenshteinDistance(a, b) / maxLen;
+}
+
+/**
+ * Returns up to 3 entries from `available` most similar to `input`,
+ * filtered to those with similarity >= `threshold` (default 0.5).
+ */
+export function findSimilar(
+  input: string,
+  available: string[],
+  threshold = 0.5,
+): Array<{ value: string; score: number }> {
+  return available
+    .map(value => ({ value, score: stringSimilarity(input, value) }))
+    .filter(x => x.score >= threshold)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 3);
+}

--- a/src/waitForCondition.ts
+++ b/src/waitForCondition.ts
@@ -1,0 +1,18 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Polls `predicate` every 100 ms until it returns `true` or `timeout` ms elapses.
+ * Returns `true` if the condition was met, `false` if it timed out.
+ */
+export async function waitForCondition(
+  predicate: () => Promise<boolean>,
+  timeout: number,
+  page: Page,
+): Promise<boolean> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (await predicate()) return true;
+    await page.waitForTimeout(100).catch(() => new Promise<void>(r => setTimeout(r, 100)));
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

- Adds `waitForCondition` — generic 100ms polling predicate with configurable timeout
- Adds `ElementTracker` — browser-side WeakMap tracker for virtualized/recycled DOM lists (peek/commit pattern)
- Adds `levenshteinDistance` / `stringSimilarity` / `findSimilar` — case-weighted fuzzy string matching for "did you mean?" style errors
- Adds `StabilizationStrategies` (`contentChanged`, `rowCountIncreased`, `networkIdle`) — generalized from smart-table's version, adapted to `(rows: Locator, page: Page, action)` API without `TableContext` dependency

All four modules are zero-dependency (Playwright types only) and pass the existing 35-test suite.

Closes #32

## Test plan

- [x] `pnpm run build` — clean compile, no TS errors
- [x] `pnpm test` — 35/35 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)